### PR TITLE
Subscription REST API server

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -343,11 +343,6 @@ func formatFullVersion() string {
 	return strings.Join(parts, " ")
 }
 
-func keepalive(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(200)
-	w.Write([]byte("OK"))
-}
-
 func main() {
 	flag.Var(&fConfigs, "config", "configuration file to load")
 	flag.Var(&fConfigDirs, "config-directory", "directory containing additional *.conf files")

--- a/docs/COMMANDS_AND_FLAGS.md
+++ b/docs/COMMANDS_AND_FLAGS.md
@@ -39,6 +39,7 @@ telegraf [flags]
 |`--test`                         |enable test mode: gather metrics once and print them. **No outputs are executed!**|
 |`--test-wait`                    |wait up to this many seconds for service inputs to complete in test or once mode.  **Implies `--test` if not used with `--once`**|
 |`--usage <plugin>`               |print usage for a plugin, ie, `telegraf --usage mysql`|
+|`--subscription-addr <address>`  |address to listen on for subscription for stats and state updates. If empty then subscription server is not started. Subscription server requires to specify at least one config directory via --config-directory|
 |`--version`                      |display the version and exit|
 
 ## Examples

--- a/internal/subscription/README.md
+++ b/internal/subscription/README.md
@@ -1,0 +1,36 @@
+# Subscription server
+Subscription server implements Alert API subscription. See OpenAPI specification
+for mor details
+
+https://github.com/extremenetworks/wns_openapi/blob/main/openapi/alerts/platform.yaml
+
+# Structure of the code
+* `subscription.go` - Starts HTTP listeners, instantiates stats/state handlers, perform generic handling of REST API requests. Stats/State handlers must implement `SubscriptionConfigration` interface.
+* `cpu.go` - Updates configuration for `cpu` input plugin. Updates/removes config file `cpu.conf`.
+
+# Future development
+Use `cpu.go` as an example when adding handlers for updating plugings for stats and state updates.
+For each new handler, the following steps must be implemented:
+* Add a source file to package `subscription`, named according to the metric, for example `mem.go` or `temperature.go`
+* Define config file name for the metric. The config file name should be unique for the metric. Example: `var cfgFileName string = "cpu.conf"`
+* Define template for the content of the config file, that corresponds to the plugin. Example:
+```
+var cfgStatsCpuTemplate string = `
+# Read metrics about cpu usage
+[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = true
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+  ## If true, collect raw CPU time metrics
+  collect_cpu_time = false
+  ## If true, compute and report the sum of all non-idle CPU states
+  report_active = false
+  interval = "%ds"
+```
+* Implement methods
+    * `UpdateConfig(cfg SubscriptionRequest) error`
+    * `DeleteConfig() error`
+* Update file `subscrition.go` method `Start()` by adding new handler to map of handlers. Example: `h.statsConfigHandlers["cpu"] = &SubscriptionConfigrationStatsCpu{ConfigDir: h.ConfigDir}`
+In the map the key is metric name. The metric name must match last part of the REST API endpoint path. For example, path for subscription to CPU utilization is `v1/subscribe/stats/cpu`, so name of the metric is `cpu`.
+

--- a/internal/subscription/README.md
+++ b/internal/subscription/README.md
@@ -4,6 +4,41 @@ for mor details
 
 https://github.com/extremenetworks/wns_openapi/blob/main/openapi/alerts/platform.yaml
 
+# How to use subscription server
+Start `telegraf` with parameters `--subscription-addr` and `--config-directory`. Config directory must exists and can be empty. Specify a port for `--subscription-addr`, that is not used by other applications:
+```
+telegraf --config telegraf.conf --subscription-addr :35000 --config-directory conf.d
+```
+Send subscription command using curl:
+```
+curl -X POST http://localhost:35000/v1/subscribe/stats/cpu -d '{ "interval": 30, "samplePeriod": 6 }'
+```
+Telegraf will create/update config file:
+```
+% cat ~/git/telegraf/conf.d/cpu.conf                                                                   
+
+# Read metrics about cpu usage
+[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = true
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+  ## If true, collect raw CPU time metrics
+  collect_cpu_time = false
+  ## If true, compute and report the sum of all non-idle CPU states
+  report_active = false
+  interval = "30s"
+```
+
+Telegraf will re-read configuration and restart automatically:
+```
+2022-04-29T19:49:53Z I! Updated config file conf.d/cpu.conf
+2022-04-29T19:49:53Z I! Reloading Telegraf config
+2022-04-29T19:49:53Z I! [agent] Hang on, flushing any cached metrics before shutdown
+2022-04-29T19:49:53Z I! [agent] Stopping running outputs
+2022-04-29T19:49:53Z I! Starting Telegraf 1.21.4-55d994a6
+```
+
 # Structure of the code
 * `subscription.go` - Starts HTTP listeners, instantiates stats/state handlers, perform generic handling of REST API requests. Stats/State handlers must implement `SubscriptionConfigration` interface.
 * `cpu.go` - Updates configuration for `cpu` input plugin. Updates/removes config file `cpu.conf`.

--- a/internal/subscription/cpu.go
+++ b/internal/subscription/cpu.go
@@ -1,0 +1,49 @@
+package subscription
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+type SubscriptionConfigrationStatsCpu struct {
+	ConfigDir string
+}
+
+var cfgFileName string = "cpu.conf"
+var cfgStatsCpuTemplate string = `
+# Read metrics about cpu usage
+[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = true
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+  ## If true, collect raw CPU time metrics
+  collect_cpu_time = false
+  ## If true, compute and report the sum of all non-idle CPU states
+  report_active = false
+  interval = "%ds"
+`
+
+func (h *SubscriptionConfigrationStatsCpu) UpdateConfig(cfg SubscriptionRequest) error {
+	cfgFullName := h.ConfigDir + "/" + cfgFileName
+	cfgFileContent := fmt.Sprintf(cfgStatsCpuTemplate, cfg.Interval)
+	err := os.WriteFile(cfgFullName, []byte(cfgFileContent), 0644)
+	if err == nil {
+		log.Printf("I! Updated config file %s\n", cfgFullName)
+	} else {
+		log.Printf("E! Failed to write file %s: %+v\n", cfgFullName, err)
+	}
+	return err
+}
+
+func (h *SubscriptionConfigrationStatsCpu) DeleteConfig() error {
+	cfgFullName := h.ConfigDir + "/" + cfgFileName
+	err := os.Remove(cfgFullName)
+	if err == nil {
+		log.Printf("I! Removed config file %s\n", cfgFullName)
+	} else {
+		log.Printf("E! Failed to remove file %s: %+v\n", cfgFullName, err)
+	}
+	return err
+}

--- a/internal/subscription/subscription.go
+++ b/internal/subscription/subscription.go
@@ -1,0 +1,207 @@
+package subscription
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type SubscriptionRequest struct {
+	Interval     int `json:"interval"`
+	SamplePeriod int `json:"samplePeriod"`
+}
+
+type SubscriptionConfigration interface {
+	UpdateConfig(cfg SubscriptionRequest) error
+	DeleteConfig() error
+}
+
+type SubscriptionListener struct {
+	Address             string
+	ConfigDir           string
+	listener            net.Listener
+	statsConfigHandlers map[string]SubscriptionConfigration
+	stateConfigHandlers map[string]SubscriptionConfigration
+}
+
+// Standard HTTP response definition
+type HttpResponse struct {
+	ErrorCode    int    `json:"errorCode"`
+	ErrorMessage string `json:"errorMessage"`
+	Resource     string `json:"resource"`
+}
+
+// Method to send standard HTTP response
+// Parameters:
+//  * w http.ResponseWriter: HTTP output stream
+//  * rc int: HTTP return code
+//  * msg string: Error/success message with additional details
+//  * resource string: request URL
+// Returns:
+//  * None
+func response(w http.ResponseWriter, rc int, msg string, resource string) {
+	w.WriteHeader(rc)
+	w.Header().Set("Content-Type", "application/json")
+	resp := make([]HttpResponse, 1)
+	resp[0] = HttpResponse{ErrorCode: rc, ErrorMessage: msg, Resource: resource}
+	jpl, err := json.Marshal(resp)
+	if err != nil {
+		log.Printf("E! Failed to encode JSON %+v\n", resp)
+		return
+	}
+	w.Write(jpl)
+}
+
+func (h *SubscriptionListener) subscribeStats(metric string, w http.ResponseWriter, r *http.Request) {
+	handler, ok := h.statsConfigHandlers[metric]
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	var pl SubscriptionRequest
+	err := json.NewDecoder(r.Body).Decode(&pl)
+	if err != nil {
+		log.Printf("E! Failed to parse payload: %+v\n", err)
+		response(w, http.StatusBadRequest, err.Error(), r.URL.Path)
+		return
+	}
+	err = handler.UpdateConfig(pl)
+	if err == nil {
+		// telegraf re-read config when receives SIGHUP
+		syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+		response(w, http.StatusOK, "Success", r.URL.Path)
+	} else {
+		response(w, http.StatusBadRequest, err.Error(), r.URL.Path)
+	}
+}
+
+func (h *SubscriptionListener) stopStats(metric string, w http.ResponseWriter, r *http.Request) {
+	handler, ok := h.statsConfigHandlers[metric]
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	err := handler.DeleteConfig()
+	if err == nil {
+		// telegraf re-read config when receives SIGHUP
+		syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+		response(w, http.StatusOK, "Success", r.URL.Path)
+	} else {
+		response(w, http.StatusBadRequest, err.Error(), r.URL.Path)
+	}
+}
+
+func (h *SubscriptionListener) subscribeState(metric string, w http.ResponseWriter, r *http.Request) {
+	handler, ok := h.stateConfigHandlers[metric]
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	var pl SubscriptionRequest
+	err := json.NewDecoder(r.Body).Decode(&pl)
+	if err != nil {
+		log.Printf("E! Failed to parse payload: %+v\n", err)
+		response(w, http.StatusBadRequest, err.Error(), r.URL.Path)
+		return
+	}
+	err = handler.UpdateConfig(pl)
+	if err == nil {
+		// telegraf re-read config when receives SIGHUP
+		syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+		response(w, http.StatusOK, "Success", r.URL.Path)
+	} else {
+		response(w, http.StatusBadRequest, err.Error(), r.URL.Path)
+	}
+}
+
+func (h *SubscriptionListener) stopState(metric string, w http.ResponseWriter, r *http.Request) {
+	handler, ok := h.stateConfigHandlers[metric]
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	err := handler.DeleteConfig()
+	if err == nil {
+		// telegraf re-read config when receives SIGHUP
+		syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+		response(w, http.StatusOK, "Success", r.URL.Path)
+	} else {
+		response(w, http.StatusBadRequest, err.Error(), r.URL.Path)
+	}
+}
+
+func (h *SubscriptionListener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := strings.Split(r.URL.Path, "/")
+	if len(path) == 5 && path[1] == "v1" && path[2] == "subscribe" {
+		if path[3] == "stats" {
+			switch r.Method {
+			case "POST":
+				h.subscribeStats(path[4], w, r)
+				return
+			case "DELETE":
+				h.stopStats(path[4], w, r)
+				return
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+		}
+		if path[3] == "state" {
+			switch r.Method {
+			case "POST":
+				h.subscribeState(path[4], w, r)
+				return
+			case "DELETE":
+				h.stopState(path[4], w, r)
+				return
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func (h *SubscriptionListener) Start() error {
+	h.statsConfigHandlers = map[string]SubscriptionConfigration{}
+	h.statsConfigHandlers["cpu"] = &SubscriptionConfigrationStatsCpu{ConfigDir: h.ConfigDir}
+
+	var listener net.Listener
+	listener, err := net.Listen("tcp", h.Address)
+	if err != nil {
+		return err
+	}
+	h.listener = listener
+	log.Printf("I! Starting REST API subscription server at: %s", h.Address)
+
+	server := &http.Server{
+		Addr:         h.Address,
+		Handler:      h,
+		ReadTimeout:  time.Duration(30 * time.Second),
+		WriteTimeout: time.Duration(30 * time.Second),
+	}
+
+	if err := server.Serve(h.listener); err != nil {
+		if !errors.Is(err, net.ErrClosed) {
+			fmt.Printf("Serve failed: %v", err)
+		}
+	}
+	return nil
+}
+
+func (h *SubscriptionListener) Stop() {
+	if h.listener != nil {
+		// Ignore the returned error as we cannot do anything about it anyway
+		//nolint:errcheck,revive
+		h.listener.Close()
+	}
+}

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -43,6 +43,7 @@ The commands & flags are:
   --test-wait                    wait up to this many seconds for service inputs to complete
                                  in test or once mode. Implies --test if not used with --once.
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
+  --subscription-addr <address>  address to listen on for subscription for stats and state updates. If empty then subscription server is not started. Subscription server requires to specify at least one config directory via --config-directory
   --version                      display the version and exit
 
 Examples:


### PR DESCRIPTION
# Subscription server
Subscription server implements Alert API subscription. See OpenAPI specification
for mor details

https://github.com/extremenetworks/wns_openapi/blob/main/openapi/alerts/platform.yaml

# Purpose of this pull request
This pull request represents a proposed way of implementing Alert API subscription server in telegraf code. Handler for `/v1/subscribe/stats/cpu` is implemented as an example.

# How to use subscription server
Start `telegraf` with parameters `--subscription-addr` and `--config-directory`. Config directory must exists and can be empty. Specify a port for `--subscription-addr`, that is not used by other applications:
```
telegraf --config telegraf.conf --subscription-addr :35000 --config-directory conf.d
```
Send subscription command using curl:
```
curl -X POST http://localhost:35000/v1/subscribe/stats/cpu -d '{ "interval": 30, "samplePeriod": 6 }'
```
Telegraf will create/update config file:
```
% cat ~/git/telegraf/conf.d/cpu.conf                                                                   

# Read metrics about cpu usage
[[inputs.cpu]]
  ## Whether to report per-cpu stats or not
  percpu = true
  ## Whether to report total system cpu stats or not
  totalcpu = true
  ## If true, collect raw CPU time metrics
  collect_cpu_time = false
  ## If true, compute and report the sum of all non-idle CPU states
  report_active = false
  interval = "30s"
```

Telegraf will re-read configuration and restart automatically:
```
2022-04-29T19:49:53Z I! Updated config file conf.d/cpu.conf
2022-04-29T19:49:53Z I! Reloading Telegraf config
2022-04-29T19:49:53Z I! [agent] Hang on, flushing any cached metrics before shutdown
2022-04-29T19:49:53Z I! [agent] Stopping running outputs
2022-04-29T19:49:53Z I! Starting Telegraf 1.21.4-55d994a6
```

# Structure of the code
* `subscription.go` - Starts HTTP listeners, instantiates stats/state handlers, perform generic handling of REST API requests. Stats/State handlers must implement `SubscriptionConfigration` interface.
* `cpu.go` - Updates configuration for `cpu` input plugin. Updates/removes config file `cpu.conf`.

# Future development
Use `cpu.go` as an example when adding handlers for updating plugings for stats and state updates.
For each new handler, the following steps must be implemented:
* Add a source file to package `subscription`, named according to the metric, for example `mem.go` or `temperature.go`
* Define config file name for the metric. The config file name should be unique for the metric. Example: `var cfgFileName string = "cpu.conf"`
* Define template for the content of the config file, that corresponds to the plugin. Example:
```
var cfgStatsCpuTemplate string = `
# Read metrics about cpu usage
[[inputs.cpu]]
  ## Whether to report per-cpu stats or not
  percpu = true
  ## Whether to report total system cpu stats or not
  totalcpu = true
  ## If true, collect raw CPU time metrics
  collect_cpu_time = false
  ## If true, compute and report the sum of all non-idle CPU states
  report_active = false
  interval = "%ds"
```
* Implement methods
    * `UpdateConfig(cfg SubscriptionRequest) error`
    * `DeleteConfig() error`
* Update file `subscrition.go` method `Start()` by adding new handler to map of handlers. Example: `h.statsConfigHandlers["cpu"] = &SubscriptionConfigrationStatsCpu{ConfigDir: h.ConfigDir}`
In the map the key is metric name. The metric name must match last part of the REST API endpoint path. For example, path for subscription to CPU utilization is `v1/subscribe/stats/cpu`, so name of the metric is `cpu`.

