### PR TITLE
Reduce executable size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
-	"github.com/influxdata/telegraf/internal/choice"
+	//"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/aggregators"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -1449,6 +1449,7 @@ func (c *Config) getParserConfig(name string, tbl *ast.Table) (*parsers.Config, 
 
 	c.getFieldString(tbl, "value_field_name", &pc.ValueFieldName)
 
+    /*
 	//for XPath parser family
 	if choice.Contains(pc.DataFormat, []string{"xml", "xpath_json", "xpath_msgpack", "xpath_protobuf"}) {
 		c.getFieldString(tbl, "xpath_protobuf_file", &pc.XPathProtobufFile)
@@ -1482,6 +1483,7 @@ func (c *Config) getParserConfig(name string, tbl *ast.Table) (*parsers.Config, 
 			}
 		}
 	}
+    */
 
 	//for JSONPath parser
 	if node, ok := tbl.Fields["json_v2"]; ok {
@@ -1610,9 +1612,11 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 	c.getFieldStringSlice(tbl, "wavefront_source_override", &sc.WavefrontSourceOverride)
 	c.getFieldBool(tbl, "wavefront_use_strict", &sc.WavefrontUseStrict)
 
+    /*
 	c.getFieldBool(tbl, "prometheus_export_timestamp", &sc.PrometheusExportTimestamp)
 	c.getFieldBool(tbl, "prometheus_sort_metrics", &sc.PrometheusSortMetrics)
 	c.getFieldBool(tbl, "prometheus_string_as_label", &sc.PrometheusStringAsLabel)
+    */
 
 	if c.hasErrs() {
 		return nil, c.firstErr()

--- a/plugins/aggregators/all/all.go
+++ b/plugins/aggregators/all/all.go
@@ -9,6 +9,6 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/aggregators/merge"
 	_ "github.com/influxdata/telegraf/plugins/aggregators/minmax"
 	_ "github.com/influxdata/telegraf/plugins/aggregators/quantile"
-	_ "github.com/influxdata/telegraf/plugins/aggregators/starlark"
+	// _ "github.com/influxdata/telegraf/plugins/aggregators/starlark"
 	_ "github.com/influxdata/telegraf/plugins/aggregators/valuecounter"
 )

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -14,7 +14,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
-	"github.com/influxdata/telegraf/plugins/parsers/prometheus"
+	//"github.com/influxdata/telegraf/plugins/parsers/prometheus"
 )
 
 const sampleConfig = `
@@ -101,15 +101,17 @@ func (e *Execd) cmdReadOut(out io.Reader) {
 		return
 	}
 
-	_, isPrometheus := e.parser.(*prometheus.Parser)
+	// _, isPrometheus := e.parser.(*prometheus.Parser)
 
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
 		data := scanner.Bytes()
-		if isPrometheus {
+		/*
+        if isPrometheus {
 			data = append(data, []byte("\n")...)
 		}
+        */
 
 		metrics, err := e.parser.Parse(data)
 		if err != nil {

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -15,11 +15,11 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers/json_v2"
 	"github.com/influxdata/telegraf/plugins/parsers/logfmt"
 	"github.com/influxdata/telegraf/plugins/parsers/nagios"
-	"github.com/influxdata/telegraf/plugins/parsers/prometheus"
-	"github.com/influxdata/telegraf/plugins/parsers/prometheusremotewrite"
+	//"github.com/influxdata/telegraf/plugins/parsers/prometheus"
+	//"github.com/influxdata/telegraf/plugins/parsers/prometheusremotewrite"
 	"github.com/influxdata/telegraf/plugins/parsers/value"
 	"github.com/influxdata/telegraf/plugins/parsers/wavefront"
-	"github.com/influxdata/telegraf/plugins/parsers/xpath"
+	//"github.com/influxdata/telegraf/plugins/parsers/xpath"
 )
 
 type ParserFunc func() (Parser, error)
@@ -156,23 +156,27 @@ type Config struct {
 	// FormData configuration
 	FormUrlencodedTagKeys []string `toml:"form_urlencoded_tag_keys"`
 
+    /*
 	// Prometheus configuration
 	PrometheusIgnoreTimestamp bool `toml:"prometheus_ignore_timestamp"`
+    */
 
 	// Value configuration
 	ValueFieldName string `toml:"value_field_name"`
-
+    
+    /*
 	// XPath configuration
 	XPathPrintDocument bool   `toml:"xpath_print_document"`
 	XPathProtobufFile  string `toml:"xpath_protobuf_file"`
 	XPathProtobufType  string `toml:"xpath_protobuf_type"`
 	XPathConfig        []XPathConfig
+    */
 
 	// JSONPath configuration
 	JSONV2Config []JSONV2Config `toml:"json_v2"`
 }
 
-type XPathConfig xpath.Config
+// type XPathConfig xpath.Config
 
 type JSONV2Config struct {
 	json_v2.Config
@@ -261,14 +265,15 @@ func NewParser(config *Config) (Parser, error) {
 			config.DefaultTags,
 			config.FormUrlencodedTagKeys,
 		)
-	case "prometheus":
+	/*
+    case "prometheus":
 		parser, err = NewPrometheusParser(
 			config.DefaultTags,
 			config.PrometheusIgnoreTimestamp,
 		)
 	case "prometheusremotewrite":
 		parser, err = NewPrometheusRemoteWriteParser(config.DefaultTags)
-	case "xml", "xpath_json", "xpath_msgpack", "xpath_protobuf":
+    case "xml", "xpath_json", "xpath_msgpack", "xpath_protobuf":
 		parser = &xpath.Parser{
 			Format:              config.DataFormat,
 			ProtobufMessageDef:  config.XPathProtobufFile,
@@ -277,6 +282,7 @@ func NewParser(config *Config) (Parser, error) {
 			DefaultTags:         config.DefaultTags,
 			Configs:             NewXPathParserConfigs(config.MetricName, config.XPathConfig),
 		}
+    */
 	case "json_v2":
 		parser, err = NewJSONPathParser(config.JSONV2Config)
 	default:
@@ -384,6 +390,7 @@ func NewFormUrlencodedParser(
 	}, nil
 }
 
+/*
 func NewPrometheusParser(defaultTags map[string]string, ignoreTimestamp bool) (Parser, error) {
 	return &prometheus.Parser{
 		DefaultTags:     defaultTags,
@@ -407,6 +414,7 @@ func NewXPathParserConfigs(metricName string, cfgs []XPathConfig) []xpath.Config
 	}
 	return configs
 }
+*/
 
 func NewJSONPathParser(jsonv2config []JSONV2Config) (Parser, error) {
 	configs := make([]json_v2.Config, len(jsonv2config))

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -12,8 +12,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers/json"
 	"github.com/influxdata/telegraf/plugins/serializers/msgpack"
 	"github.com/influxdata/telegraf/plugins/serializers/nowmetric"
-	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
-	"github.com/influxdata/telegraf/plugins/serializers/prometheusremotewrite"
+	//"github.com/influxdata/telegraf/plugins/serializers/prometheus"
+	//"github.com/influxdata/telegraf/plugins/serializers/prometheusremotewrite"
 	"github.com/influxdata/telegraf/plugins/serializers/splunkmetric"
 	"github.com/influxdata/telegraf/plugins/serializers/wavefront"
 )
@@ -104,7 +104,8 @@ type Config struct {
 	// Use Strict rules to sanitize metric and tag names from invalid characters for Wavefront
 	// When enabled forward slash (/) and comma (,) will be accepted
 	WavefrontUseStrict bool `toml:"wavefront_use_strict"`
-
+    
+    /*
 	// Include the metric timestamp on each sample.
 	PrometheusExportTimestamp bool `toml:"prometheus_export_timestamp"`
 
@@ -115,6 +116,7 @@ type Config struct {
 	// Output string fields as metric labels; when false string fields are
 	// discarded.
 	PrometheusStringAsLabel bool `toml:"prometheus_string_as_label"`
+    */
 }
 
 // NewSerializer a Serializer interface based on the given config.
@@ -136,10 +138,12 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewCarbon2Serializer(config.Carbon2Format, config.Carbon2SanitizeReplaceChar)
 	case "wavefront":
 		serializer, err = NewWavefrontSerializer(config.Prefix, config.WavefrontUseStrict, config.WavefrontSourceOverride)
+    /*
 	case "prometheus":
 		serializer, err = NewPrometheusSerializer(config)
 	case "prometheusremotewrite":
 		serializer, err = NewPrometheusRemoteWriteSerializer(config)
+    */
 	case "msgpack":
 		serializer, err = NewMsgpackSerializer()
 	case "extr":
@@ -150,6 +154,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	return serializer, err
 }
 
+/*
 func NewPrometheusRemoteWriteSerializer(config *Config) (Serializer, error) {
 	sortMetrics := prometheusremotewrite.NoSortMetrics
 	if config.PrometheusExportTimestamp {
@@ -189,6 +194,7 @@ func NewPrometheusSerializer(config *Config) (Serializer, error) {
 		StringHandling:  stringAsLabels,
 	})
 }
+*/
 
 func NewWavefrontSerializer(prefix string, useStrict bool, sourceOverride []string) (Serializer, error) {
 	return wavefront.NewSerializer(prefix, useStrict, sourceOverride)


### PR DESCRIPTION
This commit reduces the executable size by ~50%

* Removed all references to XPATH and Prometheus data formats because they pull in a protobuf dependency
* Removed the prometheus reference from the execd input plugin(we use influx)
* Removed the starlark plugin

Information about the removed data formats here
https://github.com/extremenetworks/telegraf/tree/master/plugins/parsers/xpath
https://github.com/extremenetworks/telegraf/tree/master/plugins/parsers/prometheus
https://github.com/extremenetworks/telegraf/tree/master/plugins/parsers/prometheusremotewrite

Started all stats on Fabric Engine and Telegraf seems to work as before