### PR TITLE
Set default GOARM type for GOARCH=arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 
-LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) -X main.branch=$(branch) -X main.goos=$(GOOS) -X main.goarch=$(GOARCH)
+LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) -X main.branch=$(branch) -X main.goos=$(GOOS) -X main.goarch=$(GOARCH) 
+ifeq ($(GOARCH), arm)
+	LDFLAGS := $(LDFLAGS) -X main.goarm=$(GOARM)
+endif
 ifneq ($(tag),)
 	LDFLAGS += -X main.version=$(version)
 else

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,9 @@ set -e
 
 export LDFLAGS="-w -s"
 
+# Default ARM type for arm architecture
+arm_type=5
+
 usage()
 {
     echo "usage: $0 arch {build | upload}"
@@ -24,8 +27,7 @@ build()
 {
     make clean
     rm -f ${target}
-#    make LDFLAGS="-w -s" CGO_ENABLED=0 GOOS=linux GOARCH=${bld_arch} GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org
-    make CGO_ENABLED=0 GOOS=linux GOARCH=${bld_arch} GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org
+    make CGO_ENABLED=0 GOOS=linux GOARCH=${bld_arch} GOARM=${arm_type} GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org
     tar -cf ${target} telegraf MIT generic_MIT
     rm -f telegraf
 }


### PR DESCRIPTION
When GOARCH=arm, we were not setting a GOARM value.  When compiling with go1.20 or earlier, GOARM=5 by default.  However, for go1.21 or later GOARM=7 by default, which causes binary to crash on our arm platform.

## Summary
Set default GOARM=5 for GOARCH=arm in Extreme specific build.sh script.

## Checklist
- [x ] No AI generated code was used in this PR

