### PR TITLE
All the client connected details were not seen in _show telegraf wireless stats client stats

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -883,15 +883,19 @@ func Gather_Rf_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 			acc.AddGauge("RfStats", fields, nil)
 
+			var s string
+
 			for k, v := range fields {
 				if  fmt.Sprint(v) == "0" { // Check if the value is zero
 					delete(fields, k)
+				} else {
+					s = s + k + " : " + fmt.Sprint(v) + "\n"
 				}
 			}
 
-			var s string
-			s = string(fmt.Sprint(fields))
-			//log.Printf("%s",s)
+			s = s + "---------------------------------------------------------------------------------------------"
+
+			log.Printf("ah_wireless: radio status is processed")
 
 			dumpOutput(RF_STAT_OUT_FILE, s, 1)
 
@@ -1229,15 +1233,19 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 	}
 	t.numclient =  total_client_count
 
+	var s string
+
 	for k, v := range fields2 {
-		if  fmt.Sprint(v) == "0" { // Check if the value is zero
-			delete(fields2, k)
+        if  fmt.Sprint(v) == "0" { // Check if the value is zero
+            delete(fields2, k)
+        } else {
+			s = s + k + " : " + fmt.Sprint(v) + "\n"
 		}
 	}
 
-	var s string
-	s = string(fmt.Sprint(fields2))
-	//log.Printf("%s",s)
+	s = s + "---------------------------------------------------------------------------------------------"
+
+	log.Printf("ah_wireless: client status is processed")
 
 	dumpOutput(CLT_STAT_OUT_FILE, s, 1)
 	return nil

--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"os/exec"
 	"fmt"
+	"sort"
 	"unsafe"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -885,15 +886,27 @@ func Gather_Rf_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 			var s string
 
+			s = "Stats of interface " + intfName + "\n\n"
+
 			for k, v := range fields {
 				if  fmt.Sprint(v) == "0" { // Check if the value is zero
 					delete(fields, k)
-				} else {
-					s = s + k + " : " + fmt.Sprint(v) + "\n"
 				}
 			}
 
-			s = s + "---------------------------------------------------------------------------------------------"
+			keys := make([]string, 0, len(fields))
+
+			for k := range fields{
+				keys = append(keys, k)
+            }
+
+			sort.Strings(keys)
+
+			for _, k := range keys {
+				s = s + k + " : " + fmt.Sprint(fields[k]) + "\n"
+			}
+
+			s = s + "---------------------------------------------------------------------------------------------\n"
 
 			log.Printf("ah_wireless: radio status is processed")
 
@@ -916,6 +929,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 	var total_client_count int
 	var ii int
+	var client_mac string
 	total_client_count = 0
 	ii = 0
 
@@ -926,7 +940,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 		var ifindex2 int
 		var numassoc int
 		var stainfo *ah_ieee80211_sta_info
-		var client_mac string
+
 
 		var tx_total		int64
 		var rx_total		int64
@@ -1235,15 +1249,27 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 	var s string
 
+	s = "Stats of client [" + client_mac + "]\n\n"
+
 	for k, v := range fields2 {
         if  fmt.Sprint(v) == "0" { // Check if the value is zero
             delete(fields2, k)
-        } else {
-			s = s + k + " : " + fmt.Sprint(v) + "\n"
-		}
+        }
+    }
+
+	keys := make([]string, 0, len(fields2))
+
+	for k := range fields2{
+		keys = append(keys, k)
 	}
 
-	s = s + "---------------------------------------------------------------------------------------------"
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		s = s + k + " : " + fmt.Sprint(fields2[k]) + "\n"
+	}
+
+	s = s + "---------------------------------------------------------------------------------------------\n"
 
 	log.Printf("ah_wireless: client status is processed")
 

--- a/plugins/inputs/ah_wireless/ah_wireless_defines.go
+++ b/plugins/inputs/ah_wireless/ah_wireless_defines.go
@@ -681,6 +681,7 @@ type  ah_ieee80211_sta_stats_item struct {
 //#ifdef AH_NETWORK360_WIFI_STATS
 		ns_sq_group			[AH_SQ_TYPE_MAX][AH_SQ_GROUP_MAX]ah_signal_quality_stats
 //#endif
+		padding			[6]byte
 }
 
 


### PR DESCRIPTION
Due to padding of a structure is different in
"C" and "Golang", size of 
struct ah_ieee80211_sta_stats_item is different.
This results improper data alignment when 
retrieved using ioctl call. Adding 6 byte of
padding here to align between the two.