### PR TITLE
All the client connected details were not seen

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless_defines.go
+++ b/plugins/inputs/ah_wireless/ah_wireless_defines.go
@@ -681,6 +681,7 @@ type  ah_ieee80211_sta_stats_item struct {
 //#ifdef AH_NETWORK360_WIFI_STATS
 		ns_sq_group			[AH_SQ_TYPE_MAX][AH_SQ_GROUP_MAX]ah_signal_quality_stats
 //#endif
+		padding			[6]byte
 }
 
 


### PR DESCRIPTION
Due to padding of a structure is different in
"C" and "Golang", size of
struct ah_ieee80211_sta_stats_item is different.
This results improper data alignment when
retrieved using ioctl call. Adding 6 byte of
padding here to align between the two.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
