### PR TITLE
TELEGRAF-6: ah_wireless input plugins ioctl error

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -382,7 +382,7 @@ func load_arp_table(t *Ah_wireless) {
 
 }
 
-func getFeIpnetScore(fd uintptr, clmac [MACADDR_LEN]uint8) int {
+func getFeIpnetScore(fd uintptr, clmac [MACADDR_LEN]uint8) int32 {
 
 	msg := ah_flow_get_sta_net_health_msg{
 					mac: clmac,
@@ -689,17 +689,17 @@ func Gather_Rf_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 				total_util := atrStat.atr_info[atrStat.count - 1].rxc_pcnt
 
-				var chan_util int
-				var interface_utiliation int
+				var chan_util int32
+				var interface_utiliation int32
 				if total_util > 100 {
 					chan_util = 100
 				} else {
-					chan_util = int(total_util)
+					chan_util = int32(total_util)
 				}
 
 				/* Calculate Utilization */
 				if (total_util > (rx_util + tx_util)) {
-					interface_utiliation = int(total_util) - int(rx_util) - int(tx_util)
+					interface_utiliation = int32(total_util) - int32(rx_util) - int32(tx_util)
 				} else {
 					interface_utiliation = 0
 				}

--- a/plugins/inputs/ah_wireless/ah_wireless_defines.go
+++ b/plugins/inputs/ah_wireless/ah_wireless_defines.go
@@ -450,13 +450,13 @@ type ieee80211_node_rate_stats struct {
 }
 
 type utilization_data struct {
-	intfer_util_min		int
-	intfer_util_max		int
-	intfer_util_avg		int
+	intfer_util_min		int32
+	intfer_util_max		int32
+	intfer_util_avg		int32
 
-	chan_util_min		int
-	chan_util_max		int
-	chan_util_avg		int
+	chan_util_min		int32
+	chan_util_max		int32
+	chan_util_avg		int32
 
 	tx_util_min			int32
 	tx_util_max			int32
@@ -474,9 +474,9 @@ type utilization_data struct {
 	rx_obss_util_max	int32
 	rx_obss_util_avg	int32
 
-	wifi_i_util_min		int
-	wifi_i_util_max		int
-	wifi_i_util_avg		int
+	wifi_i_util_min		int32
+	wifi_i_util_max		int32
+	wifi_i_util_avg		int32
 
 	noise_min			int16
 	noise_max			int16
@@ -744,14 +744,14 @@ type ah_fw_dev_ip_msg struct {
 
 /* FE ioctl generic data structure */
 type ah_fe_ioctl_hdr struct {
-	retval		int			/* return value */
+	retval		int32			/* return value */
 	msg_type	uint16		/* sub message type */
 	msg_size	uint16		/* I/O msg size not including header */
 }
 
 type ah_flow_get_sta_net_health_msg struct {
 	mac			[MACADDR_LEN]uint8
-	net_health_score	int
+	net_health_score	int32
 }
 
 type  ieee80211req_sta_info struct{
@@ -840,7 +840,7 @@ type ah_flow_get_sta_server_ip_msg struct {
     mac        [MACADDR_LEN]uint8
     client_static_ip uint32
     dhcp_server    uint32
-    dhcp_time   int
+    dhcp_time   int32
     gateway    uint32
     dns     [AH_MAX_DNS_LIST]ah_dns_time
     num_dns_servers    uint8


### PR DESCRIPTION
size of int is different in golang and C. In 32 bit system, size of int is 4 in golang. But when 64 bit system is used, size of int becomes 8. Where as in C size of int is always 4 regardless of CPU. This
is creating struct interpretation wrong in ioctl
handler in 64 bit systems [AP5K]. Correcting it to use int32 instead of int.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
