### PR TITLE
Priv dhanav hos 21765

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -964,6 +964,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 		numassoc = int(getNumAssocs(t.fd, intfName2))
 
 		if(numassoc == 0) {
+			ii++
 			continue
 		}
 


### PR DESCRIPTION
Root Cause: The client count for the WiFi1 interface is reported as 0, while the WiFi0 interface shows the client count for WiFi1 if WiFi0 has no clients.

Resolution:  ii is incremented to next index if there are no clients connected on current interface
