### PR TITLE
HOS-21765 Client count for wifi1 issue fix

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -1190,10 +1190,10 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 			fields2["name"]			= string(onesta.isi_name[:])
                         fields2["host"]			= ""
                         fields2["profName"]		= "default-profile"			/* TBD (Needs shared memory of dcd)	*/
-                        fields2["dhcpIp"]		= sta_ip.dhcp_server
-			fields2["gwIp"]			= sta_ip.gateway
-                        fields2["dnsIp"]		= sta_ip.dns[0].dns_ip
-			fields2["clientIp"]		= sta_ip.client_static_ip
+                        fields2["dhcpIp"]		= intToIp(sta_ip.dhcp_server)
+			fields2["gwIp"]			= intToIp(sta_ip.gateway)
+                        fields2["dnsIp"]		= intToIp(sta_ip.dns[0].dns_ip)
+			fields2["clientIp"]		= intToIp(sta_ip.client_static_ip)
                         fields2["dhcpTime"]		= sta_ip.dhcp_time
                         fields2["gwTime"]		= 0					/* TBD (Needs shared memory of auth2)     */
                         fields2["dnsTime"]		= sta_ip.dns[0].dns_response_time

--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -964,6 +964,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 		numassoc = int(getNumAssocs(t.fd, intfName2))
 
 		if(numassoc == 0) {
+			ii++
 			continue
 		}
 


### PR DESCRIPTION
Root Cause: The client count for the WiFi1 interface is reported as 0, while the WiFi0 interface shows the client count of WiFi1 if WiFi0 has no clients.
![image](https://github.com/user-attachments/assets/9c67f6f0-4dba-4f6d-a14e-6202c60ed18f)


Resolution: ii is incremented to next index if there are no clients connected on current interface
![image](https://github.com/user-attachments/assets/f14da80e-525b-4b24-b016-eceaf07015d5)

IP addess in ipv4 format
![image](https://github.com/user-attachments/assets/3dd7cfee-d999-47c3-bfa9-2050b5571854)


