### PR TITLE
HOS-21709 Rx util as sum of inbss obss and no cat

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -1051,6 +1051,15 @@ func Gather_Rf_Avg(t *Ah_wireless, acc telegraf.Accumulator) error {
 				}
 				t.last_ut_data[ii].rx_obss_util_avg = (t.last_ut_data[ii].rx_obss_util_avg + atrStat.atr_info[atrStat.count - 1].rxf_obss)/2
 
+
+                                if (t.last_ut_data[ii].wifi_i_util_min == 0) || (t.last_ut_data[ii].wifi_i_util_min >= atrStat.atr_info[atrStat.count-1].wifi_interference) {
+                                        t.last_ut_data[ii].wifi_i_util_min = atrStat.atr_info[atrStat.count-1].wifi_interference
+                                }
+                                if (t.last_ut_data[ii].wifi_i_util_max == 0) || (t.last_ut_data[ii].wifi_i_util_max <= atrStat.atr_info[atrStat.count-1].wifi_interference) {
+                                        t.last_ut_data[ii].wifi_i_util_max = atrStat.atr_info[atrStat.count-1].wifi_interference
+                                }
+                                t.last_ut_data[ii].wifi_i_util_avg = (t.last_ut_data[ii].wifi_i_util_avg + atrStat.atr_info[atrStat.count-1].wifi_interference) / 2
+
 				/* Calculate Utilization */
 
 			}

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -1052,6 +1052,14 @@ func Gather_Rf_Avg(t *Ah_wireless, acc telegraf.Accumulator) error {
 				}
 				t.last_ut_data[ii].rx_obss_util_avg = (t.last_ut_data[ii].rx_obss_util_avg + atrStat.atr_info[atrStat.count - 1].rxf_obss)/2
 
+				if (t.last_ut_data[ii].wifi_i_util_min == 0) || (t.last_ut_data[ii].wifi_i_util_min >= atrStat.atr_info[atrStat.count-1].wifi_interference) {
+                                        t.last_ut_data[ii].wifi_i_util_min = atrStat.atr_info[atrStat.count-1].wifi_interference
+                                }
+                                if (t.last_ut_data[ii].wifi_i_util_max == 0) || (t.last_ut_data[ii].wifi_i_util_max <= atrStat.atr_info[atrStat.count-1].wifi_interference) {
+                                        t.last_ut_data[ii].wifi_i_util_max = atrStat.atr_info[atrStat.count-1].wifi_interference
+                                }
+                                t.last_ut_data[ii].wifi_i_util_avg = (t.last_ut_data[ii].wifi_i_util_avg + atrStat.atr_info[atrStat.count-1].wifi_interference) / 2
+
 				/* Calculate Utilization */
 
 			}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The utilization data for the "No category" is not updated during the first nine minutes; only the value from the 10th minute is considered, leading to a significant discrepancy between the combined inBSS, OBSS, and "no category" values and the RX utilization.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
