### PR TITLE
Removing extra characters from SSID

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -1881,7 +1881,11 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 		for cn := 0; cn < numassoc; cn++ {
 
-			client_ssid = string(bytes.Trim(clt_item[cn].ns_ssid[:], "\x00"))
+			client_ssid = strings.TrimSpace(string(bytes.Trim(clt_item[cn].ns_ssid[:], "\x00")))
+
+			if idx := strings.IndexByte(client_ssid, '\x00'); idx >= 0 {
+				client_ssid = client_ssid[:idx]
+			}
 
 			if(clt_item[cn].ns_mac[0] !=0 || clt_item[cn].ns_mac[1] !=0 || clt_item[cn].ns_mac[2] !=0 || clt_item[cn].ns_mac[3] !=0 || clt_item[cn].ns_mac[4] != 0 || clt_item[cn].ns_mac[5]!=0) {
 				cintfName := t.intf_m[intfName2][client_ssid]

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -1877,7 +1877,11 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 		for cn := 0; cn < numassoc; cn++ {
 
-			client_ssid = string(bytes.Trim(clt_item[cn].ns_ssid[:], "\x00"))
+			client_ssid = strings.TrimSpace(string(bytes.Trim(clt_item[cn].ns_ssid[:], "\x00")))
+
+			if idx := strings.IndexByte(client_ssid, '\x00'); idx >= 0 {
+				client_ssid = client_ssid[:idx]
+			}
 
 			if(clt_item[cn].ns_mac[0] !=0 || clt_item[cn].ns_mac[1] !=0 || clt_item[cn].ns_mac[2] !=0 || clt_item[cn].ns_mac[3] !=0 || clt_item[cn].ns_mac[4] != 0 || clt_item[cn].ns_mac[5]!=0) {
 				cintfName := t.intf_m[intfName2][client_ssid]


### PR DESCRIPTION
SSID field was containing extra characters
causing error in ioctl function. Fixed
this issue here.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
