### PR TITLE
HOS-22750: Dump output for nw and dev stat

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -2858,7 +2858,34 @@ func Send_NetworkStats(t *Ah_wireless, acc telegraf.Accumulator) error {
 		}
 
 		acc.AddGauge("NetworkStats", fields, nil)
+
+		var s string
+
+		s = "Stats of interface " + t.if_stats[i].ifname + "\n\n"
+
+		for k, v := range fields {
+			if  fmt.Sprint(v) == "0" { // Check if the value is zero
+				delete(fields, k)
+			}
+		}
+
+		keys := make([]string, 0, len(fields))
+
+		for k := range fields{
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			s = s + k + " : " + fmt.Sprint(fields[k]) + "\n"
+		}
+
+		s = s + "---------------------------------------------------------------------------------------------\n"
+
 		log.Printf("network status is processed")
+
+		dumpOutput(NW_STAT_OUT_FILE, s, 1)
 	}
 	return nil
 }
@@ -2935,7 +2962,33 @@ func Send_DeviceStats(t *Ah_wireless, acc telegraf.Accumulator) error {
 		}
 
 		acc.AddGauge("DeviceStats", fields, nil)
+
+		var s string
+
+		s = "-----------------------------------------------\n\n"
+
+		for k, v := range fields {
+			if  fmt.Sprint(v) == "0" { // Check if the value is zero
+				delete(fields, k)
+			}
+		}
+
+		keys := make([]string, 0, len(fields))
+
+		for k := range fields{
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			s = s + k + " : " + fmt.Sprint(fields[k]) + "\n"
+		}
+
+		s = s + "---------------------------------------------------------------------------------------------\n"
+
 		log.Printf("device status is processed")
+		dumpOutput(DEV_STAT_OUT_FILE, s, 1)
 	}
 	return nil
 }
@@ -3214,6 +3267,8 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
 	if t.timer_count == 9 {
 		dumpOutput(RF_STAT_OUT_FILE, "RF Stat Input Plugin Output", 0)
 		dumpOutput(CLT_STAT_OUT_FILE, "Client Stat Input Plugin Output", 0)
+		dumpOutput(NW_STAT_OUT_FILE, "Network Stat Input Plugin Output",0)
+		dumpOutput(DEV_STAT_OUT_FILE, "Device Stat Input Plugin Output",0)
 		for _, intfName := range t.Ifname {
 			t.intf_m[intfName] = make(map[string]string)
 			load_ssid(t, intfName)

--- a/plugins/inputs/ah_wireless/ah_wireless_defines_3000.go
+++ b/plugins/inputs/ah_wireless/ah_wireless_defines_3000.go
@@ -1,4 +1,4 @@
-// +build !AP4020
+// +build AP3000
 
 package ah_wireless
 
@@ -32,6 +32,8 @@ const (
 	AH_MAX_DNS_LIST =		4
 	RF_STAT_OUT_FILE =		"/tmp/rfStatOut"
 	CLT_STAT_OUT_FILE =		"/tmp/clientStatOut"
+	NW_STAT_OUT_FILE =		"/tmp/NetworkStatOut"
+	DEV_STAT_OUT_FILE =		"/tmp/DeviceStatOut"
 	EVT_SOCK =			"/tmp/ah_telegraf.sock"
 	AH_MAX_ETH =			2
 	AH_MAX_WLAN =			4
@@ -1151,7 +1153,6 @@ type ifreq_eth struct {
 type ah_ethif_cmd struct {
 	cmd uint16
 	ifname [unix.IFNAMSIZ]byte
-	pad1 [6]byte
 	ifr ifreq_eth
 }
 

--- a/plugins/inputs/ah_wireless/ah_wireless_defines_4020.go
+++ b/plugins/inputs/ah_wireless/ah_wireless_defines_4020.go
@@ -32,6 +32,8 @@ const (
 	AH_MAX_DNS_LIST =		4
 	RF_STAT_OUT_FILE =		"/tmp/rfStatOut"
 	CLT_STAT_OUT_FILE =		"/tmp/clientStatOut"
+	NW_STAT_OUT_FILE =		"/tmp/NetworkStatOut"
+	DEV_STAT_OUT_FILE =		"/tmp/DeviceStatOut"
 	EVT_SOCK =			"/tmp/ah_telegraf.sock"
 	AH_MAX_ETH =			2
 	AH_MAX_WLAN =			4

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -2836,7 +2836,34 @@ func Send_NetworkStats(t *Ah_wireless, acc telegraf.Accumulator) error {
 		}
 
 		acc.AddGauge("NetworkStats", fields, nil)
+
+		var s string
+
+		s = "Stats of interface " + t.if_stats[i].ifname + "\n\n"
+
+		for k, v := range fields {
+			if  fmt.Sprint(v) == "0" { // Check if the value is zero
+				delete(fields, k)
+			}
+		}
+
+		keys := make([]string, 0, len(fields))
+
+		for k := range fields{
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			s = s + k + " : " + fmt.Sprint(fields[k]) + "\n"
+		}
+
+		s = s + "---------------------------------------------------------------------------------------------\n"
+
 		log.Printf("network status is processed")
+
+		dumpOutput(NW_STAT_OUT_FILE, s, 1)
 	}
 	return nil
 }
@@ -2913,7 +2940,33 @@ func Send_DeviceStats(t *Ah_wireless, acc telegraf.Accumulator) error {
 		}
 
 		acc.AddGauge("DeviceStats", fields, nil)
+
+		var s string
+
+		s = "-----------------------------------------------\n\n"
+
+		for k, v := range fields {
+			if  fmt.Sprint(v) == "0" { // Check if the value is zero
+				delete(fields, k)
+			}
+		}
+
+		keys := make([]string, 0, len(fields))
+
+		for k := range fields{
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			s = s + k + " : " + fmt.Sprint(fields[k]) + "\n"
+		}
+
+		s = s + "---------------------------------------------------------------------------------------------\n"
+
 		log.Printf("device status is processed")
+		dumpOutput(DEV_STAT_OUT_FILE, s, 1)
 	}
 	return nil
 }
@@ -3192,6 +3245,9 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
 	if t.timer_count == 9 {
 		dumpOutput(RF_STAT_OUT_FILE, "RF Stat Input Plugin Output", 0)
 		dumpOutput(CLT_STAT_OUT_FILE, "Client Stat Input Plugin Output", 0)
+		dumpOutput(NW_STAT_OUT_FILE, "Network Stat Input Plugin Output",0)
+		dumpOutput(DEV_STAT_OUT_FILE, "Device Stat Input Plugin Output",0)
+
 		for _, intfName := range t.Ifname {
 			t.intf_m[intfName] = make(map[string]string)
 			load_ssid(t, intfName)


### PR DESCRIPTION
Dumping output of network and device stats
to a file. This change also includes seperation
of define files in AP3K and AP5K.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
