### PR TITLE
HOS-23265: Adding rrm id in ClientStat and RfStat

### DIFF
--- a/plugins/common/ahutil/ahutil.go
+++ b/plugins/common/ahutil/ahutil.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"bufio"
+	"strconv"
 )
 
 func Mystr() string {
@@ -381,4 +382,18 @@ func GetAPName() string {
         return "NA"
     }
     return "NA"
+}
+
+func GetRrmId() int {
+	var ret int
+	ret = 0
+	content, err := os.ReadFile("/tmp/rrmid")
+	if err != nil {
+		return 0
+	}
+	ret, err = strconv.Atoi(string(content))
+	if err != nil {
+		return 0
+	}
+	return ret
 }

--- a/plugins/inputs/ah_airrm/ah_airrm.go
+++ b/plugins/inputs/ah_airrm/ah_airrm.go
@@ -146,8 +146,10 @@ func Gather_acs_nbr(ai *Ah_airrm, acc telegraf.Accumulator) error {
 			}
 
 			fields["rrmId"] =						nbrtbl.nbr_tbl[i].rrmId
-			fields["channel"] = 					ahutil.FreqToChan(uint16(nbrtbl.nbr_tbl[i].frequency))
+			fields["channel"] =					ahutil.FreqToChan(uint16(nbrtbl.nbr_tbl[i].frequency))
 			fields["channelWidth"] =				nbrtbl.nbr_tbl[i].channelWidth
+			fields["rssi"] =					nbrtbl.nbr_tbl[i].rssi
+			fields["extremeAP"] =					nbrtbl.nbr_tbl[i].extremeAP == 1
 			fields["channelUtilization"] =			nbrtbl.nbr_tbl[i].channelUtilization
 			fields["interferenceUtilization"] =		nbrtbl.nbr_tbl[i].interferenceUtilization
 			fields["rxObssUtilization"] =			nbrtbl.nbr_tbl[i].obssUtilization

--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -17,12 +17,14 @@ import (
 	"runtime/debug"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/common/ahutil"
 	"golang.org/x/sys/unix"
 )
 
 var (
 	offsetsMutex = new(sync.Mutex)
 	newLineByte  = []byte("\n")
+	rrmid int = 0
 )
 
 
@@ -1767,6 +1769,7 @@ func Gather_Rf_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 		}
 
 			fields["band"] = get_radio_band(t, intfName)
+			fields["rrmId"] = rrmid
 
 			if (t.last_ut_data[ii].noise_min == 0) || (t.last_ut_data[ii].noise_min >= rfstat.ast_noise_floor) {
 				t.last_ut_data[ii].noise_min = rfstat.ast_noise_floor
@@ -2669,6 +2672,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 			fields2["ifName"]			= intfName2
 			fields2["ifIndex"]			= ifindex2
+			fields2["rrmId"]			= rrmid
 			fields2["channel"]			= freqToChan(onesta.isi_freq)
 			fields2["channelWidth"]		= getChannelWidth(onesta.isi_phymode)
 
@@ -3451,6 +3455,8 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
 		}
 
 		Gather_EthernetInterfaceStats(t)
+
+		rrmid = ahutil.GetRrmId()
 
 		Gather_Client_Stat(t, acc)
 		Gather_Rf_Stat(t, acc)

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -17,12 +17,14 @@ import (
 	"runtime/debug"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/common/ahutil"
 	"golang.org/x/sys/unix"
 )
 
 var (
 	offsetsMutex = new(sync.Mutex)
 	newLineByte  = []byte("\n")
+	rrmid int = 0
 )
 
 
@@ -1765,6 +1767,7 @@ func Gather_Rf_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 		}
 
 			fields["band"] = get_radio_band(t, intfName)
+			fields["rrmId"] = rrmid
 
 			if (t.last_ut_data[ii].noise_min == 0) || (t.last_ut_data[ii].noise_min >= rfstat.ast_noise_floor) {
 				t.last_ut_data[ii].noise_min = rfstat.ast_noise_floor
@@ -2669,6 +2672,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 			fields2["ifName"]			= intfName2
 			fields2["ifIndex"]			= ifindex2
+			fields2["rrmId"]                        = rrmid
 			fields2["channel"]			= freqToChan(onesta.isi_freq)
 			fields2["channelWidth"]		= getChannelWidth(onesta.isi_phymode)
 
@@ -3452,6 +3456,8 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
 		}
 
 		Gather_EthernetInterfaceStats(t)
+
+		rrmid = ahutil.GetRrmId()
 
 		Gather_Client_Stat(t, acc)
 		Gather_Rf_Stat(t, acc)


### PR DESCRIPTION
This change includes rrm id in client stat and
rf stat telemetry data.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
