### PR TITLE
HOS-23590 Added TxPower in rfstats and nbrStats

### DIFF
--- a/plugins/common/ahutil/ahutil.go
+++ b/plugins/common/ahutil/ahutil.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"bufio"
 	"strconv"
+	"os/exec"
 )
 
 func Mystr() string {
@@ -397,3 +398,38 @@ func GetRrmId() int {
 	}
 	return ret
 }
+
+// Utility function to get tx power using 'wl -i ifname txpwr' command
+func GetTxPower(ifname string) int8 {
+	app := "wl"
+
+	arg0 := "-i"
+	arg1 := ifname
+	arg2 := "txpwr"
+
+	cmd := exec.Command(app, arg0, arg1, arg2)
+	output, err := cmd.Output()
+	if err != nil {
+		return -1
+	}
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "dBm") && strings.Contains(line, "mw") {
+			// Example line: "18.0 dBm = 63 mw." or "0.0 dBm = 1 mw"
+			fields := strings.Fields(line)
+			for i, f := range fields {
+				if f == "dBm" && i > 0 {
+					// Get the dBm value (before "dBm")
+					dBmStr := fields[i-1]
+					// Parse as float first to handle decimal values like "18.0"
+					dBmFloat, err := strconv.ParseFloat(dBmStr, 64)
+					if err == nil {
+						return int8(dBmFloat)
+					}
+				}
+			}
+		}
+	}
+	return -1
+}
+

--- a/plugins/common/ahutil/ahutil.go
+++ b/plugins/common/ahutil/ahutil.go
@@ -401,6 +401,12 @@ func GetRrmId() int {
 
 // Utility function to get tx power using 'wl -i ifname txpwr' command
 func GetTxPower(ifname string) int8 {
+
+	// Validation: check if ifname is not blank and contains "wifi"
+	if ifname == "" || !strings.Contains(ifname, "wifi") {
+		return -1
+	}
+
 	app := "wl"
 
 	arg0 := "-i"

--- a/plugins/inputs/ah_airrm/ah_airrm.go
+++ b/plugins/inputs/ah_airrm/ah_airrm.go
@@ -149,6 +149,7 @@ func Gather_acs_nbr(ai *Ah_airrm, acc telegraf.Accumulator) error {
 			fields["channel"] =					ahutil.FreqToChan(uint16(nbrtbl.nbr_tbl[i].frequency))
 			fields["channelWidth"] =				nbrtbl.nbr_tbl[i].channelWidth
 			fields["rssi"] =					nbrtbl.nbr_tbl[i].rssi
+			fields["txPower"] =                                        nbrtbl.nbr_tbl[i].txPower
 			fields["extremeAP"] =					nbrtbl.nbr_tbl[i].extremeAP == 1
 			fields["channelUtilization"] =			nbrtbl.nbr_tbl[i].channelUtilization
 			fields["interferenceUtilization"] =		nbrtbl.nbr_tbl[i].interferenceUtilization

--- a/plugins/inputs/ah_airrm/ah_airrm_defines.go
+++ b/plugins/inputs/ah_airrm/ah_airrm_defines.go
@@ -50,6 +50,7 @@ type ah_ieee80211_airrm_nbr_t struct {
 	timestamp				uint64			// Date and timestamp
 	extremeAP				uint8			// Is AP managed by Extreme?
 	rssi					int8			// RSS value in dBm
+	txPower                                 int8                    // Transmit power in dBm
 	bssid					[MACADDR_LEN]byte		// BSSID
 	radioMode				uint8			// Radio mode: 0=Access, 1=Sensor, 2=Backhaul, 3=Dual
     ssid					[32]byte		// SSID

--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -1184,6 +1184,7 @@ func Gather_Rf_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 			fields["band"] = get_radio_band(t, intfName)
 			fields["rrmId"] = rrmid
+			fields["txPower"] = ahutil.GetTxPower(intfName)
 
 			if (t.last_ut_data[ii].noise_min == 0) || (t.last_ut_data[ii].noise_min >= rfstat.ast_noise_floor) {
 				t.last_ut_data[ii].noise_min = rfstat.ast_noise_floor

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -1182,6 +1182,7 @@ func Gather_Rf_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 
 			fields["band"] = get_radio_band(t, intfName)
 			fields["rrmId"] = rrmid
+			fields["txPower"] = ahutil.GetTxPower(intfName)
 
 			if (t.last_ut_data[ii].noise_min == 0) || (t.last_ut_data[ii].noise_min >= rfstat.ast_noise_floor) {
 				t.last_ut_data[ii].noise_min = rfstat.ast_noise_floor


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
1. Added txPower to rfStats by using the wl command for the active interface
2. Updated the nbrSats structure to include txPower in nbrStats, utilizing the same ioctl command.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
