### PR TITLE
HOS-23737  Implemented on demand debug command for wireless stats

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -37,6 +37,10 @@ type Ah_wireless struct {
 	Ifname			[]string	`toml:"ifname"`
 	Eth_ioctl		uint64		`toml:"eth_ioctl"`
 	Scount			uint8		`toml:"scount"`
+	Test_rf_enable	    uint8		`toml:"test_rf_enable"`
+	Test_client_enable  uint8		`toml:"test_client_enable"`
+	Test_device_enable  uint8		`toml:"test_device_enable"`
+	Test_network_enable uint8		`toml:"test_network_enable"`
 	closed			chan		struct{}
 	numclient		[4]int
 	timer_count		uint8
@@ -191,6 +195,10 @@ const sampleConfig = `
   scount = 10
   ifname = ["wifi0","wifi1"]
   eth_ioctl = -6767123671
+  Test_rf_enable = 0
+  Test_client_enable = 0
+  Test_device_enable = 0
+  Test_network_enable = 0
 `
 func NewAh_wireless(id int) *Ah_wireless {
 	var err error
@@ -210,6 +218,10 @@ func NewAh_wireless(id int) *Ah_wireless {
 				timer_count: 0,
 				Eth_ioctl: 0,
 				Scount: 10,
+				Test_rf_enable: 0,
+				Test_client_enable: 0,
+				Test_device_enable: 0,
+				Test_network_enable: 0,
         }
 
 }
@@ -2552,14 +2564,80 @@ func Gather_deffer_end(t *Ah_wireless) {
 	}
 }
 
+func (t *Ah_wireless) runWirelessStats(
+    enableWirelessStat *uint8,
+    wirelessStatOutFile string,
+    wirelessStatTitle string,
+    preWirelessStat func(),
+    collectWirelessStat func(),
+) {
+    if *enableWirelessStat != 1 {
+        return
+    }
+    dumpOutput(wirelessStatOutFile, wirelessStatTitle, 0)
+    if preWirelessStat != nil {
+        preWirelessStat()
+    }
+    collectWirelessStat()
+    *enableWirelessStat = 0
+}
+
 func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
+    t.wg.Add(1)
+    log.Printf("ah_wireless: Gather Rf stat mode=%d Client=%d Device=%d Network=%d\n",
+        t.Test_rf_enable, t.Test_client_enable, t.Test_device_enable, t.Test_network_enable)
 
-	t.wg.Add(1)
+    go func() {
+        defer Gather_deffer_end(t)
 
-	go func() {
+        // If ANY test flag set, do shared interface + ssid prep once.
+        if t.Test_rf_enable == 1 || t.Test_client_enable == 1 ||
+            t.Test_device_enable == 1 || t.Test_network_enable == 1 {
+            for _, ifn := range t.Ifname {
+                t.intf_m[ifn] = make(map[string]string)
+                load_ssid(t, ifn)
+            }
+        }
 
-		defer Gather_deffer_end(t)
+        // RF one-shot (set rrmid only here)
+        if t.Test_rf_enable == 1 {
+            rrmid = ahutil.GetRrmId()
+        }
+        t.runWirelessStats(&t.Test_rf_enable,
+            RF_STAT_OUT_FILE,
+            "RF Stat Input Plugin Output",
+            nil,
+            func() { Gather_Rf_Stat(t, acc) },
+        )
 
+        // Client one-shot
+        t.runWirelessStats(&t.Test_client_enable,
+            CLT_STAT_OUT_FILE,
+            "Client Stat Input Plugin Output",
+            nil,
+            func() { Gather_Client_Stat(t, acc) },
+        )
+
+        // Device one-shot (needs health + service first)
+        t.runWirelessStats(&t.Test_device_enable,
+            DEV_STAT_OUT_FILE,
+            "Device Stat Input Plugin Output",
+            func() {
+                Gather_Network_Health(t)
+                Gather_Network_Service(t)
+            },
+            func() { Send_DeviceStats(t, acc) },
+        )
+
+        // Network one-shot (needs ethernet interface stats first)
+        t.runWirelessStats(&t.Test_network_enable,
+            NW_STAT_OUT_FILE,
+            "Network Stat Input Plugin Output",
+            func() { Gather_EthernetInterfaceStats(t) },
+            func() { Send_NetworkStats(t, acc) },
+        )
+
+        // Periodic / aggregated path
 		if t.timer_count == (t.Scount - 1) {
 			dumpOutput(RF_STAT_OUT_FILE, "RF Stat Input Plugin Output", 0)
 			dumpOutput(CLT_STAT_OUT_FILE, "Client Stat Input Plugin Output", 0)

--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -37,10 +37,10 @@ type Ah_wireless struct {
 	Ifname			[]string	`toml:"ifname"`
 	Eth_ioctl		uint64		`toml:"eth_ioctl"`
 	Scount			uint8		`toml:"scount"`
-	Test_rfstats_enable	uint8		`toml:"test_rfstats_enable"`
-	Test_client_enable  uint8		`toml:"test_client_enable"`
-	Test_device_enable  uint8		`toml:"test_device_enable"`
-	Test_network_enable uint8		`toml:"test_network_enable"`
+	Test_rf_stats_enable	  uint8		`toml:"test_rf_stats_enable"`
+	Test_client_stats_enable  uint8		`toml:"test_client_stats_enable"`
+	Test_device_stats_enable  uint8		`toml:"test_device_stats_enable"`
+	Test_network_stats_enable uint8		`toml:"test_network_stats_enable"`
 	closed			chan		struct{}
 	numclient		[4]int
 	timer_count		uint8
@@ -195,10 +195,10 @@ const sampleConfig = `
   scount = 10
   ifname = ["wifi0","wifi1"]
   eth_ioctl = -6767123671
-  Test_rfstats_enable = 0
-  Test_client_enable = 0
-  Test_device_enable = 0
-  Test_network_enable = 0
+  Test_rf_stats_enable = 0
+  Test_client_stats_enable = 0
+  Test_device_stats_enable = 0
+  Test_network_stats_enable = 0
 `
 func NewAh_wireless(id int) *Ah_wireless {
 	var err error
@@ -218,10 +218,10 @@ func NewAh_wireless(id int) *Ah_wireless {
 				timer_count: 0,
 				Eth_ioctl: 0,
 				Scount: 10,
-				Test_rfstats_enable: 0,
-				Test_client_enable: 0,
-				Test_device_enable: 0,
-				Test_network_enable: 0,
+				Test_rf_stats_enable: 0,
+				Test_client_stats_enable: 0,
+				Test_device_stats_enable: 0,
+				Test_network_stats_enable: 0,
         }
 
 }
@@ -2601,18 +2601,18 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
         defer Gather_deffer_end(t)
 
         // If ANY test flag set, do shared interface + ssid prep once.
-        if t.Test_rfstats_enable == 1 || t.Test_client_enable == 1 ||
-            t.Test_device_enable == 1 || t.Test_network_enable == 1 {
+        if t.Test_rf_stats_enable == 1 || t.Test_client_stats_enable == 1 ||
+            t.Test_device_stats_enable == 1 || t.Test_network_stats_enable == 1 {
             for _, ifn := range t.Ifname {
                 t.intf_m[ifn] = make(map[string]string)
                 load_ssid(t, ifn)
             }
 
         // RF one-shot (set rrmid only here)
-        if t.Test_rfstats_enable == 1 {
+        if t.Test_rf_stats_enable == 1 {
             rrmid = ahutil.GetRrmId()
         }
-        t.runWirelessStats(&t.Test_rfstats_enable,
+        t.runWirelessStats(&t.Test_rf_stats_enable,
             RF_STAT_OUT_FILE,
             "RF Stat Input Plugin Output",
             nil,
@@ -2620,7 +2620,7 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
         )
 
         // Client one-shot
-        t.runWirelessStats(&t.Test_client_enable,
+        t.runWirelessStats(&t.Test_client_stats_enable,
             CLT_STAT_OUT_FILE,
             "Client Stat Input Plugin Output",
             nil,
@@ -2628,7 +2628,7 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
         )
 
         // Device one-shot (needs health + service first)
-        t.runWirelessStats(&t.Test_device_enable,
+        t.runWirelessStats(&t.Test_device_stats_enable,
             DEV_STAT_OUT_FILE,
             "Device Stat Input Plugin Output",
             func() {
@@ -2639,7 +2639,7 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
         )
 
         // Network one-shot (needs ethernet interface stats first)
-        t.runWirelessStats(&t.Test_network_enable,
+        t.runWirelessStats(&t.Test_network_stats_enable,
             NW_STAT_OUT_FILE,
             "Network Stat Input Plugin Output",
             func() { Gather_EthernetInterfaceStats(t) },

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -37,7 +37,7 @@ type Ah_wireless struct {
 	Ifname			[]string	`toml:"ifname"`
 	Eth_ioctl		uint64		`toml:"eth_ioctl"`
 	Scount			uint8		`toml:"scount"`
-	Test_rf_enable	    uint8		`toml:"test_rf_enable"`
+	Test_rfstats_enable	uint8		`toml:"test_rfstats_enable"`
 	Test_client_enable  uint8		`toml:"test_client_enable"`
 	Test_device_enable  uint8		`toml:"test_device_enable"`
 	Test_network_enable uint8		`toml:"test_network_enable"`
@@ -195,7 +195,7 @@ const sampleConfig = `
   scount = 10
   ifname = ["wifi0","wifi1"]
   eth_ioctl = -6767123671
-  Test_rf_enable = 0
+  Test_rfstats_enable = 0
   Test_client_enable = 0
   Test_device_enable = 0
   Test_network_enable = 0
@@ -218,7 +218,7 @@ func NewAh_wireless(id int) *Ah_wireless {
 				timer_count: 0,
 				Eth_ioctl: 0,
 				Scount: 10,
-				Test_rf_enable: 0,
+				Test_rfstats_enable: 0,
 				Test_client_enable: 0,
 				Test_device_enable: 0,
 				Test_network_enable: 0,
@@ -2579,12 +2579,15 @@ func (t *Ah_wireless) runWirelessStats(
     if *enableWirelessStat != 1 {
         return
     }
-    dumpOutput(wirelessStatOutFile, wirelessStatTitle, 0)
+   
     if preWirelessStat != nil {
         preWirelessStat()
     }
-    collectWirelessStat()
+	if collectWirelessStat != nil {
+        collectWirelessStat()
+    }
     *enableWirelessStat = 0
+
 }
 
 
@@ -2596,19 +2599,18 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
         defer Gather_deffer_end(t)
 
         // If ANY test flag set, do shared interface + ssid prep once.
-        if t.Test_rf_enable == 1 || t.Test_client_enable == 1 ||
+        if t.Test_rfstats_enable == 1 || t.Test_client_enable == 1 ||
             t.Test_device_enable == 1 || t.Test_network_enable == 1 {
             for _, ifn := range t.Ifname {
                 t.intf_m[ifn] = make(map[string]string)
                 load_ssid(t, ifn)
             }
-        }
-
-        // RF one-shot (set rrmid only here)
-        if t.Test_rf_enable == 1 {
+        
+		// RF one-shot (set rrmid only here)
+        if t.Test_rfstats_enable == 1 {
             rrmid = ahutil.GetRrmId()
         }
-        t.runWirelessStats(&t.Test_rf_enable,
+        t.runWirelessStats(&t.Test_rfstats_enable,
             RF_STAT_OUT_FILE,
             "RF Stat Input Plugin Output",
             nil,
@@ -2641,6 +2643,7 @@ func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
             func() { Gather_EthernetInterfaceStats(t) },
             func() { Send_NetworkStats(t, acc) },
         )
+	}
 
         // Periodic / aggregated path
 

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -37,6 +37,10 @@ type Ah_wireless struct {
 	Ifname			[]string	`toml:"ifname"`
 	Eth_ioctl		uint64		`toml:"eth_ioctl"`
 	Scount			uint8		`toml:"scount"`
+	Test_rf_enable	    uint8		`toml:"test_rf_enable"`
+	Test_client_enable  uint8		`toml:"test_client_enable"`
+	Test_device_enable  uint8		`toml:"test_device_enable"`
+	Test_network_enable uint8		`toml:"test_network_enable"`
 	closed			chan		struct{}
 	numclient		[4]int
 	timer_count		uint8
@@ -191,6 +195,10 @@ const sampleConfig = `
   scount = 10
   ifname = ["wifi0","wifi1"]
   eth_ioctl = -6767123671
+  Test_rf_enable = 0
+  Test_client_enable = 0
+  Test_device_enable = 0
+  Test_network_enable = 0
 `
 func NewAh_wireless(id int) *Ah_wireless {
 	var err error
@@ -210,6 +218,10 @@ func NewAh_wireless(id int) *Ah_wireless {
 				timer_count: 0,
 				Eth_ioctl: 0,
 				Scount: 10,
+				Test_rf_enable: 0,
+				Test_client_enable: 0,
+				Test_device_enable: 0,
+				Test_network_enable: 0,
         }
 
 }
@@ -2551,13 +2563,81 @@ func Gather_deffer_end(t *Ah_wireless) {
 	}
 }
 
+func (t *Ah_wireless) runWirelessStats(
+    enableWirelessStat *uint8,
+    wirelessStatOutFile string,
+    wirelessStatTitle string,
+    preWirelessStat func(),
+    collectWirelessStat func(),
+) {
+    if *enableWirelessStat != 1 {
+        return
+    }
+    dumpOutput(wirelessStatOutFile, wirelessStatTitle, 0)
+    if preWirelessStat != nil {
+        preWirelessStat()
+    }
+    collectWirelessStat()
+    *enableWirelessStat = 0
+}
+
 func (t *Ah_wireless) Gather(acc telegraf.Accumulator) error {
 
-	t.wg.Add(1)
+    t.wg.Add(1)
+    log.Printf("ah_wireless: Gather Rf stat mode=%d Client=%d Device=%d Network=%d\n",
+        t.Test_rf_enable, t.Test_client_enable, t.Test_device_enable, t.Test_network_enable)
 
-	go func() {
+    go func() {
+        defer Gather_deffer_end(t)
 
-		defer Gather_deffer_end(t)
+        // If ANY test flag set, do shared interface + ssid prep once.
+        if t.Test_rf_enable == 1 || t.Test_client_enable == 1 ||
+            t.Test_device_enable == 1 || t.Test_network_enable == 1 {
+            for _, ifn := range t.Ifname {
+                t.intf_m[ifn] = make(map[string]string)
+                load_ssid(t, ifn)
+            }
+        }
+
+        // RF one-shot (set rrmid only here)
+        if t.Test_rf_enable == 1 {
+            rrmid = ahutil.GetRrmId()
+        }
+        t.runWirelessStats(&t.Test_rf_enable,
+            RF_STAT_OUT_FILE,
+            "RF Stat Input Plugin Output",
+            nil,
+            func() { Gather_Rf_Stat(t, acc) },
+        )
+
+        // Client one-shot
+        t.runWirelessStats(&t.Test_client_enable,
+            CLT_STAT_OUT_FILE,
+            "Client Stat Input Plugin Output",
+            nil,
+            func() { Gather_Client_Stat(t, acc) },
+        )
+
+        // Device one-shot (needs health + service first)
+        t.runWirelessStats(&t.Test_device_enable,
+            DEV_STAT_OUT_FILE,
+            "Device Stat Input Plugin Output",
+            func() {
+                Gather_Network_Health(t)
+                Gather_Network_Service(t)
+            },
+            func() { Send_DeviceStats(t, acc) },
+        )
+
+        // Network one-shot (needs ethernet interface stats first)
+        t.runWirelessStats(&t.Test_network_enable,
+            NW_STAT_OUT_FILE,
+            "Network Stat Input Plugin Output",
+            func() { Gather_EthernetInterfaceStats(t) },
+            func() { Send_NetworkStats(t, acc) },
+        )
+
+        // Periodic / aggregated path
 
 		if t.timer_count == (t.Scount - 1) {
 			dumpOutput(RF_STAT_OUT_FILE, "RF Stat Input Plugin Output", 0)


### PR DESCRIPTION
  - Implemented Wireless Stats Support in Wireless Modules

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
1.Added one-shot and periodic collection support for all wireless stat types.
2.Updated configuration and helper functions to streamline wireless stats workflows.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
