### PR TITLE
HOS-23265: 64bit allignment for airrm struct

### DIFF
--- a/plugins/inputs/ah_airrm/ah_airrm_defines.go
+++ b/plugins/inputs/ah_airrm/ah_airrm_defines.go
@@ -43,12 +43,14 @@ type iwreq struct
 // AIRRM neighbor table structure
 type ah_ieee80211_airrm_nbr_tbl_t struct {
 	num_nbrs		uint32							// Number of neighbors
+	_pad0			[4]byte							// Padding for 64bit alignment
 	nbr_tbl			[MAX_NEIGHBOR_NUM + 1]ah_ieee80211_airrm_nbr_t		// Variable length array
 }
 
 // AIRRM neighbor information structure
 type ah_ieee80211_airrm_nbr_t struct {
 	rrmId					uint32			// unique identifier for RRM
+	_pad0					[4]byte			// pad to align timestamp (was implicit)
 	timestamp				uint64			// Date and timestamp
 	extremeAP				uint8			// Is AP managed by Extreme?
 	rssi					int8			// RSS value in dBm
@@ -62,8 +64,10 @@ type ah_ieee80211_airrm_nbr_t struct {
 	wifiInterferenceUtilization	uint8		// WiFi interference utilization
 	aggregationSize			uint16			// Aggregation size
 	packetErrorRate			uint8			// Packet error rate
+	_pad1					[1]byte			// pad for 2-byte alignment of clientCount
 	clientCount				uint16			// Client count
 	frequency				uint32			// Frequency in MHz
 	channelWidth			uint16			// Channel width in MHz
+	_pad2					[6]byte			// padding to make total size 80 bytes (multiple of 8)
 }
 


### PR DESCRIPTION
Adding pads to ai rrm structure to make it
64bit allignement to support in AP3000

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
