### PR TITLE
HOS-24011: 1st character of RfNbrStats should be with uppercase

### DIFF
--- a/plugins/inputs/ah_airrm/ah_airrm.go
+++ b/plugins/inputs/ah_airrm/ah_airrm.go
@@ -174,7 +174,7 @@ func Gather_acs_nbr(ai *Ah_airrm, acc telegraf.Accumulator) error {
 			fields["aggregationSize"] =				nbrtbl.nbr_tbl[i].aggregationSize
 			fields["clientCount"] =					nbrtbl.nbr_tbl[i].clientCount
 
-			acc.AddGauge("rfNbrStats", fields, nil)
+			acc.AddGauge("RfNbrStats", fields, nil)
 			count++
 		}
 	}


### PR DESCRIPTION
Fixing the typo of 1st character of RfNbrStats

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
