### PR TITLE
HOS-24222 Add staAddr6 in connection change trap

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -192,7 +192,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
 
                 acc.AddFields("TrapEvent", map[string]interface{}{
                         "trapObjName_clientInfoTrap":       cleanCString(ahclientinfo.Name[:]),
-                        "ssid_clientInfoTrap":              ahclientinfo.Ssid,
+			"ssid_clientInfoTrap":              cleanCString(ahclientinfo.Ssid[:]),
 			"clientMac_clientInfoTrap":         formatMac(ahclientinfo.ClientMac),
                         "hostName_clientInfoTrap":          cleanCString(ahclientinfo.HostName[:]),
 			"userName_clientInfoTrap":          cleanCString(ahclientinfo.UserName[:]),

--- a/plugins/inputs/ah_trap/ah_trap_defines.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines.go
@@ -109,7 +109,7 @@ type AhConnectionChangeTrap struct {
 	Option55               [AH_UCHAR_MAX + 1]byte
 	MgtStus                uint16
 	StaAddr6Num            uint8
-        magic                  byte
+	_                      [3]byte  // Padding for 4-byte alignment
 	StaAddr6               [AH_MAX_NUM_STA_ADDRS6][16]byte
 	DeauthReason           int32
 	RoamTime               int32
@@ -261,13 +261,15 @@ func intToIPv4(num uint32) string {
 	return ip.String()
 }
 
-func intToIPv6(addrs [][16]byte, count int) []string {
-	var result []string
-	for i := 0; i < count && i < len(addrs); i++ {
-		ip := net.IP(addrs[i][:])
-		result = append(result, ip.String())
+func intToIPv6(addrs [][16]byte, count int) string {
+	if count > 0 && count <= len(addrs) {
+		ip := net.IP(addrs[0][:])
+		ipStr := ip.String()
+		// Log raw bytes to debug alignment issues
+		fmt.Printf("[intToIPv6] count=%d, raw_bytes=%v, result='%s'\n", count, addrs[0][:], ipStr)
+		return ipStr
 	}
-	return result
+	return ""
 }
 
 func formatMac(mac [6]byte) string {

--- a/plugins/inputs/ah_trap/ah_trap_defines.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines.go
@@ -265,8 +265,6 @@ func intToIPv6(addrs [][16]byte, count int) string {
 	if count > 0 && count <= len(addrs) {
 		ip := net.IP(addrs[0][:])
 		ipStr := ip.String()
-		// Log raw bytes to debug alignment issues
-		fmt.Printf("[intToIPv6] count=%d, raw_bytes=%v, result='%s'\n", count, addrs[0][:], ipStr)
 		return ipStr
 	}
 	return ""


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Updated staAddr6 param as per the NOS-OPEN spec as a string instead of an array of string while converting integer to ipv6 address

{'trapEvent': [{'device': {'serialnumber': 'HA012235Y-10251'}, 'items': [{'connectionChangeTrap': {'assocTime': 28, 'associationTime': 1764739049, 'authTime': 0, 'authUsed': 2, 'bssid': '24:1F:BD:90:20:94', 'clientAuthMethod': 1, 'clientChannel': 1, 'clientCwpUsed': 2, 'clientEncryptMethod': 3, 'clientIp': '0.0.0.0', 'clientMacProto': 2, 'clientUpId': 0, 'clientVlan': 1, 'curState': 1, 'deauthReason': 0, 'hostName': '', 'keys': {'ifIndex': 24, 'name': 'wifi0.1'}, 'mgtStatus': 0, 'negotiateKbps': 54000, 'objectType': 1, 'option55': '', 'os': '', 'profile': 'default-profile', 'radioProfile': 'trap_2_0', 'remoteId': '9C:67:D6:59:E3:9F', 'roamTime': -1, 'rssi': 50, 'snr': -43, 'ssid': 'DHANA_AP3000_HOS-24222', **'staAddr6': 'fe80::f201:9c81:1f33:e8f6'**, 'staAddr6Num': 1, 'trapMessage': {'desc': 'Station 9c67:d659:e39f was authenticated on 241f:bd90:2094 through SSID DHANA_AP3000_HOS-24222 vid 1.\n', 'level': 5, 'msgId': 1}, **'trapObjName': 'AUTH',** 'userName': ''}}], 'name': 'TrapEvent', 'ts': 1764739051181}]}


{'trapEvent': [{'device': {'serialnumber': 'HA012235Y-10251'}, 'items': [{'clientInfoTrap': {'clientIp': '0.0.0.34', 'clientMac': '31:31:32:32:33:33', 'hostName': 'host', 'mgtStatus': 0, **'ssid': 'ssid'**, 'staAddr6': '', 'staAddr6Num': 0, 'trapMessage': {'desc': 'client info.\n', 'level': 2, 'msgId': 1}, 'trapObjName': 'client Info', 'userName': 'user'}}], 'name': 'TrapEvent', 'ts': 1764745957486}]}

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
