### PR TITLE
HOS-23657 Add trap id and trap type in DFS trap

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -404,6 +404,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 
 		acc.AddFields("TrapEvent", map[string]interface{}{
 			"trapType_dfsBangTrap":    dfs.TrapType,
+			"trapId_dfsBangTrap":      dfs.TrapId,
 			"name_dfsBangTrap":        cleanCString(dfs.IfName[:]),
 			"desc_dfsBangTrap":        cleanCString(dfs.Desc[:]),
 		}, nil)

--- a/plugins/inputs/ah_trap/ah_trap_defines.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines.go
@@ -54,6 +54,7 @@ type AhFaMvlanChangeTrap struct {
 
 type AhTgrafDfsTrap struct {
 	TrapType  uint8
+	TrapId    uint8
 //	DataLen   uint16
 //	IfNameLen uint8
 	IfName    [AH_MAX_TRAP_IF_NAME + 1]byte


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Added parameters trap id along with trap type for DFS Bang trap

{'trapEvent': [{'device': {'serialnumber': 'CV012350S-C0040'}, 'items': [{'dfsBangTrap': {'desc': 'A DFS event caused the radio to switch channels from 52 to 40.\n', 'name': 'wifi1', **'trapId': 110, 'trapType': 12**}}], 'name': 'TrapEvent', 'ts': 1764850940882}]}

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
