### PR TITLE
HOS-24233: trap AH_MSG_TRAP_STA_LEAVE_STATS

### DIFF
--- a/plugins/common/ahutil/ahutil.go
+++ b/plugins/common/ahutil/ahutil.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"os/exec"
+	"bytes"
 )
 
 func Mystr() string {
@@ -467,3 +468,77 @@ func MacToString(mac [6]byte) string {
 	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",mac[0],mac[1],mac[2],mac[3],mac[4],mac[5])
 }
 
+func GetBSSIDbyIfName(ifName string) (bssid [MACADDR_LEN]uint8, err error) {
+
+	var ret [MACADDR_LEN]uint8
+	app := "wl"
+	arg0 := "-i"
+	arg1 := ifName
+	arg2 := "bssid"
+
+	cmd := exec.Command(app, arg0, arg1, arg2)
+	out, err := cmd.Output()
+	if err != nil {
+		return ret, err
+	}
+
+	bssid_str := string(out)
+
+	bssid_str = strings.TrimSpace(bssid_str)
+	split_text := strings.Split(bssid_str, ":")
+
+	for i := 0; i < MACADDR_LEN; i++ {
+		val,err := strconv.ParseUint(split_text[i], 16, 8)
+		if err != nil {
+			return ret, err
+		}
+		ret[i] = uint8(val)
+	}
+
+	return ret, nil
+}
+
+func GetSSIDbyIfName(ifName string) (ssid string, err error) {
+
+	app := "wl"
+	arg0 := "-i"
+	arg1 := ifName
+	arg2 := "ssid"
+
+	cmd := exec.Command(app, arg0, arg1, arg2)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	outstring := string(out)
+
+	ssid_text := strings.Split(outstring, ":")
+	ssid_ret := strings.TrimSpace(ssid_text[1])[1 : len(strings.TrimSpace(ssid_text[1]))-1]
+
+	return ssid_ret, nil
+}
+
+func IntToIpv4(num uint32) string {
+
+    b := make([]byte, 4)
+    b[0] = byte(num)
+    b[1] = byte(num >> 8)
+    b[2] = byte(num >> 16)
+    b[3] = byte(num >> 24)
+    return fmt.Sprintf("%d.%d.%d.%d",b[0],b[1],b[2],b[3])
+}
+
+
+func CleanCString(b []byte) string {
+    if i := bytes.IndexByte(b, 0); i != -1 {
+        return string(b[:i])
+    }
+    return string(b)
+}
+
+
+func FormatMac(mac [6]byte) string {
+	return fmt.Sprintf("%02X:%02X:%02X:%02X:%02X:%02X",
+		mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
+}

--- a/plugins/inputs/ah_trap/ah_trap_5020.go
+++ b/plugins/inputs/ah_trap/ah_trap_5020.go
@@ -1,0 +1,139 @@
+// +build AP5020
+
+package ah_trap
+
+import (
+	"log"
+	"unsafe"
+	"fmt"
+	"strings"
+	"strconv"
+	"os/exec"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/ahutil"
+)
+
+type AhStaLeaveStatsTrap struct {
+    TrapId          uint8
+    DataLen         uint16
+    ObjNameLen      uint8
+    ObjName         [MAX_OBJ_NAME_LEN]byte
+    ReasonCode      uint32
+    DesLen          uint8
+    Describable     [MAX_DESCRIBLE_LEN]uint8
+    DisassocTime    uint32
+    IfIndex         uint32
+    Mac             [MACADDR_LEN]uint8
+    Rssi            uint32
+    LinkupTime      uint32
+    AuthMethod      uint8
+    EncryptMethod   uint8
+    MacProtocol     uint8
+    CwpUsed         uint8
+    Vlan            uint32
+    UserProfileId   uint32
+    Channel         uint32
+    LastTxrate      uint32
+    LastRxrate      uint32
+    RxDataFrames    uint32
+    RxDataOctets    uint32
+    RxMgtFrames     uint32
+    RxUcFrames      uint32
+    RxMcFrames      uint32
+    RxBcFrames      uint32
+    RxMicFailure    uint32
+    TxDataFrames    uint32
+    TxMgtFrames     uint32
+    TxDataOctets    uint32
+    TxUcFrames      uint32
+    TxMcFrames      uint32
+    TxBcFrames      uint32
+    Ip              uint32
+    HostName        [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte
+    SsidName        [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte
+    UserName        [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte
+    TxBeDataFrames  uint32
+    TxBgDataFrames  uint32
+    TxViDataFrames  uint32
+    TxVoDataFrames  uint32
+    RxAirTime       uint64
+    TxAirTime       uint64
+    ClientBssid     [MACADDR_LEN]uint8
+    Ts              uint32
+    IfName          [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte  // char array
+    StaAddr6Num     uint8
+    StaAddr6        [AH_MAX_NUM_STA_ADDRS6]AhStaAddr6
+    _               [4]byte // Padding: Forces total size to 528 bytes for 8-byte alignment
+}
+
+
+
+func (t *TrapPlugin) Ah_send_sta_leave_trap(trapType uint32, trapBuf [600]byte, acc telegraf.Accumulator) error {
+	var staLeave AhStaLeaveStatsTrap
+	var description string
+	var if_name string
+
+	copy((*[unsafe.Sizeof(staLeave)]byte)(unsafe.Pointer(&staLeave))[:], trapBuf[:unsafe.Sizeof(staLeave)])
+
+	if_name = ahutil.CleanCString(staLeave.IfName[:])
+
+	ssid,_ := ahutil.GetSSIDbyIfName(if_name)
+	bssid,_ := ahutil.GetBSSIDbyIfName(if_name)
+	
+	description = fmt.Sprintf("Station %02x%02x:%02x%02x:%02x%02x is deauthenticated from %02x%02x:%02x%02x:%02x%02x thru SSID %s\n",
+			staLeave.Mac[0], staLeave.Mac[1], staLeave.Mac[2], staLeave.Mac[3], staLeave.Mac[4], staLeave.Mac[5],
+			bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5],
+			ssid)
+
+	acc.AddFields("TrapEvent", map[string]interface{}{
+		"ifIndex_keys_staLeaveStatsTrap":		staLeave.IfIndex,
+		"name_keys_staLeaveStatsTrap":			if_name,
+
+		"trapId_staLeaveStatsTrap":				staLeave.TrapId,
+
+		"objectName_staLeaveStatsTrap":			ahutil.CleanCString(staLeave.ObjName[:]),
+		"reasonCode_staLeaveStatsTrap":			staLeave.ReasonCode,
+		"description_staLeaveStatsTrap":		description,
+		"disassocTime_staLeaveStatsTrap":		staLeave.DisassocTime,
+		"mac_staLeaveStatsTrap":				ahutil.FormatMac(staLeave.Mac),
+		"rssi_staLeaveStatsTrap":				staLeave.Rssi,
+		"linkUptime_staLeaveStatsTrap":			staLeave.LinkupTime,
+		"clientAuthMethod_staLeaveStatsTrap":		staLeave.AuthMethod,
+		"clientEncryptMethod_staLeaveStatsTrap":	staLeave.EncryptMethod,
+		"clientMacProto_staLeaveStatsTrap":		staLeave.MacProtocol,
+		"clientCwpUsed_staLeaveStatsTrap":		staLeave.CwpUsed,
+		"clientVlan_staLeaveStatsTrap":			staLeave.Vlan,
+		"clientChannel_staLeaveStatsTrap":		staLeave.Channel,
+		"lastTxrate_staLeaveStatsTrap":			staLeave.LastTxrate,
+		"lastRxrate_staLeaveStatsTrap":			staLeave.LastRxrate,
+
+		"rxdataframes_staLeaveStatsTrap":	staLeave.RxDataFrames,
+		"txdataframes_staLeaveStatsTrap":	staLeave.TxDataFrames,
+		"rxdatabytes_staLeaveStatsTrap":	staLeave.RxDataOctets,
+		"txdatabytes_staLeaveStatsTrap":	staLeave.TxDataOctets,
+		"rxmgmtframes_staLeaveStatsTrap":	staLeave.RxMgtFrames,
+		"txmgmtframes_staLeaveStatsTrap":	staLeave.TxMgtFrames,
+		"rxucframes_staLeaveStatsTrap":		staLeave.RxUcFrames,
+		"txucframes_staLeaveStatsTrap":		staLeave.TxUcFrames,
+		"rxmcframes_staLeaveStatsTrap":		staLeave.RxMcFrames,
+		"txmcframes_staLeaveStatsTrap":		staLeave.TxMcFrames,
+		"rxbcframes_staLeaveStatsTrap":		staLeave.RxBcFrames,
+		"txbcframes_staLeaveStatsTrap":		staLeave.TxBcFrames,
+		"rxmicfailures_staLeaveStatsTrap":	staLeave.RxMicFailure,
+		"clientIp_staLeaveStatsTrap":		ahutil.IntToIpv4(staLeave.Ip),
+		"hostName_staLeaveStatsTrap":		ahutil.CleanCString(staLeave.HostName[:]),
+		"userName_staLeaveStatsTrap":		ahutil.CleanCString(staLeave.UserName[:]),
+		"ssid_staLeaveStatsTrap":			ssid,
+		"bssid_staLeaveStatsTrap":			ahutil.FormatMac(bssid),
+		"txbeframes_staLeaveStatsTrap":		staLeave.TxBeDataFrames,
+		"txbgframes_staLeaveStatsTrap":		staLeave.TxBgDataFrames,
+		"txviframes_staLeaveStatsTrap":		staLeave.TxViDataFrames,
+		"txvovframes_staLeaveStatsTrap":	staLeave.TxVoDataFrames,
+		"rxairtime_staLeaveStatsTrap":		staLeave.RxAirTime,
+		"txairtime_staLeaveStatsTrap":		staLeave.TxAirTime,
+		"ts_staLeaveStatsTrap":				staLeave.Ts,
+		"staAddr6Num_staLeaveStatsTrap":	staLeave.StaAddr6Num,
+		"staAddr6_staLeaveStatsTrap":		IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)),
+	}, nil)
+	return nil
+}

--- a/plugins/inputs/ah_trap/ah_trap_all.go
+++ b/plugins/inputs/ah_trap/ah_trap_all.go
@@ -1,0 +1,125 @@
+// +build AP3000 AP5000 AP4020
+
+package ah_trap
+
+import (
+	"log"
+	"unsafe"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/ahutil"
+)
+
+type AhStaLeaveStatsTrap struct {
+    TrapId          uint8
+    DataLen         uint16
+    ObjNameLen      uint8
+    ObjName         [MAX_OBJ_NAME_LEN]byte
+    ReasonCode      uint32
+    DesLen          uint8
+    Describable     [MAX_DESCRIBLE_LEN]uint8
+    DisassocTime    uint32
+    IfIndex         uint32
+    Mac             [MACADDR_LEN]uint8
+    Rssi            uint32
+    LinkupTime      uint32
+    AuthMethod      uint8
+    EncryptMethod   uint8
+    MacProtocol     uint8
+    CwpUsed         uint8
+    Vlan            uint32
+    UserProfileId   uint32
+    Channel         uint32
+    LastTxrate      uint32
+    LastRxrate      uint32
+    RxDataFrames    uint32
+    RxDataOctets    uint32
+    RxMgtFrames     uint32
+    RxUcFrames      uint32
+    RxMcFrames      uint32
+    RxBcFrames      uint32
+    RxMicFailure    uint32
+    TxDataFrames    uint32
+    TxMgtFrames     uint32
+    TxDataOctets    uint32
+    TxUcFrames      uint32
+    TxMcFrames      uint32
+    TxBcFrames      uint32
+    Ip              uint32
+    HostName        [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte
+    SsidName        [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte
+    UserName        [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte
+    TxBeDataFrames  uint32
+    TxBgDataFrames  uint32
+    TxViDataFrames  uint32
+    TxVoDataFrames  uint32
+    RxAirTime       uint64
+    TxAirTime       uint64
+    ClientBssid     [MACADDR_LEN]uint8
+    Ts              uint32
+    IfName          [AH_CAPWAP_STAT_NAME_MAX_LEN + 1]byte  // char array
+    StaAddr6Num     uint8
+    StaAddr6        [AH_MAX_NUM_STA_ADDRS6]AhStaAddr6
+    EventReasonCode uint32
+    EventType       uint32
+    _               [4]byte // Padding: Forces total size to 528 bytes for 8-byte alignment
+}
+
+func (t *TrapPlugin) Ah_send_sta_leave_trap(trapType uint32, trapBuf [600]byte, acc telegraf.Accumulator) error {
+	var staLeave AhStaLeaveStatsTrap
+	copy((*[unsafe.Sizeof(staLeave)]byte)(unsafe.Pointer(&staLeave))[:], trapBuf[:unsafe.Sizeof(staLeave)])
+	
+	log.Printf("[ah_trap] STA LEAVE STATS trap: ObjName=%s ReasonCode=%d Describable=%s", ahutil.CleanCString(staLeave.ObjName[:]), staLeave.ReasonCode, ahutil.CleanCString(staLeave.Describable[:]))
+	acc.AddFields("TrapEvent", map[string]interface{}{
+		"ifIndex_keys_staLeaveStatsTrap":		staLeave.IfIndex,
+		"name_keys_staLeaveStatsTrap":			ahutil.CleanCString(staLeave.IfName[:]),
+
+		"trapId_staLeaveStatsTrap":				staLeave.TrapId,
+
+		"objectName_staLeaveStatsTrap":			ahutil.CleanCString(staLeave.ObjName[:]),
+		"reasonCode_staLeaveStatsTrap":			staLeave.ReasonCode,
+		"description_staLeaveStatsTrap":		ahutil.CleanCString(staLeave.Describable[:]),
+		"disassocTime_staLeaveStatsTrap":		staLeave.DisassocTime,
+		"mac_staLeaveStatsTrap":				ahutil.FormatMac(staLeave.Mac),
+		"rssi_staLeaveStatsTrap":				staLeave.Rssi,
+		"linkUptime_staLeaveStatsTrap":			staLeave.LinkupTime,
+		"clientAuthMethod_staLeaveStatsTrap":		staLeave.AuthMethod,
+		"clientEncryptMethod_staLeaveStatsTrap":	staLeave.EncryptMethod,
+		"clientMacProto_staLeaveStatsTrap":		staLeave.MacProtocol,
+		"clientCwpUsed_staLeaveStatsTrap":		staLeave.CwpUsed,
+		"clientVlan_staLeaveStatsTrap":			staLeave.Vlan,
+		"clientChannel_staLeaveStatsTrap":		staLeave.Channel,
+		"lastTxrate_staLeaveStatsTrap":			staLeave.LastTxrate,
+		"lastRxrate_staLeaveStatsTrap":			staLeave.LastRxrate,
+
+		"rxdataframes_staLeaveStatsTrap":	staLeave.RxDataFrames,
+		"txdataframes_staLeaveStatsTrap":	staLeave.TxDataFrames,
+		"rxdatabytes_staLeaveStatsTrap":	staLeave.RxDataOctets,
+		"txdatabytes_staLeaveStatsTrap":	staLeave.TxDataOctets,
+		"rxmgmtframes_staLeaveStatsTrap":	staLeave.RxMgtFrames,
+		"txmgmtframes_staLeaveStatsTrap":	staLeave.TxMgtFrames,
+		"rxucframes_staLeaveStatsTrap":		staLeave.RxUcFrames,
+		"txucframes_staLeaveStatsTrap":		staLeave.TxUcFrames,
+		"rxmcframes_staLeaveStatsTrap":		staLeave.RxMcFrames,
+		"txmcframes_staLeaveStatsTrap":		staLeave.TxMcFrames,
+		"rxbcframes_staLeaveStatsTrap":		staLeave.RxBcFrames,
+		"txbcframes_staLeaveStatsTrap":		staLeave.TxBcFrames,
+		"rxmicfailures_staLeaveStatsTrap":	staLeave.RxMicFailure,
+		"clientIp_staLeaveStatsTrap":		ahutil.IntToIpv4(staLeave.Ip),
+		"hostName_staLeaveStatsTrap":		ahutil.CleanCString(staLeave.HostName[:]),
+		"userName_staLeaveStatsTrap":		ahutil.CleanCString(staLeave.UserName[:]),
+		"ssid_staLeaveStatsTrap":			ahutil.CleanCString(staLeave.SsidName[:]),
+		"bssid_staLeaveStatsTrap":			ahutil.FormatMac(staLeave.ClientBssid),
+		"txbeframes_staLeaveStatsTrap":		staLeave.TxBeDataFrames,
+		"txbgframes_staLeaveStatsTrap":		staLeave.TxBgDataFrames,
+		"txviframes_staLeaveStatsTrap":		staLeave.TxViDataFrames,
+		"txvovframes_staLeaveStatsTrap":	staLeave.TxVoDataFrames,
+		"rxairtime_staLeaveStatsTrap":		staLeave.RxAirTime,
+		"txairtime_staLeaveStatsTrap":		staLeave.TxAirTime,
+		"ts_staLeaveStatsTrap":				staLeave.Ts,
+		"staAddr6Num_staLeaveStatsTrap":	staLeave.StaAddr6Num,
+		"staAddr6_staLeaveStatsTrap":		IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)),
+		"eventreasoncode_staLeaveStatsTrap":	staLeave.EventReasonCode,
+		"eventtype_staLeaveStatsTrap":		staLeave.EventType,
+	}, nil)
+	return nil
+}

--- a/plugins/inputs/ah_trap/ah_trap_defines.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines.go
@@ -2,7 +2,6 @@ package ah_trap
 
 
 import (
-        "fmt"
 	"net"
 )
 
@@ -23,7 +22,11 @@ const (
 	AH_FA_MVLAN_TRAP_TYPE    = 124
 	TRAP_DCRPT_LEN           = 96
 	AH_MSG_TRAP_DFS_BANG     = 12
-	MACADDR_LEN		 = 6 
+	AH_MSG_TRAP_STA_LEAVE_STATS = 6
+	MACADDR_LEN		 = 6
+	MAX_DESCRIBLE_LEN	 = 128
+	AH_CAPWAP_STAT_NAME_MAX_LEN = 32
+	MAX_OBJ_NAME_LEN		 = 4
 )
 
 const (
@@ -271,8 +274,16 @@ func intToIPv6(addrs [][16]byte, count int) string {
 	return ""
 }
 
-func formatMac(mac [6]byte) string {
-	return fmt.Sprintf("%02X:%02X:%02X:%02X:%02X:%02X",
-		mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
+func IntToIPv6_1(addrs []AhStaAddr6, count int) []string {
+	var result []string
+	for i := 0; i < count && i < len(addrs); i++ {
+		ip := net.IP(addrs[i].StaAddr6[:])
+		result = append(result, ip.String())
+	}
+	return result
 }
 
+type AhStaAddr6 struct {
+    AddrType byte      // char addr_type
+    StaAddr6 [16]byte  // struct in6_addr (IPv6 address is 16 bytes)
+}


### PR DESCRIPTION
Implementing trap AH_MSG_TRAP_STA_LEAVE_STATS
This trap is sent when a wireless station is
disconnected from the AP.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
