### PR TITLE
Fixing build error

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap_5020.go
+++ b/plugins/inputs/ah_trap/ah_trap_5020.go
@@ -3,12 +3,8 @@
 package ah_trap
 
 import (
-	"log"
 	"unsafe"
 	"fmt"
-	"strings"
-	"strconv"
-	"os/exec"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/common/ahutil"
 )


### PR DESCRIPTION
Fixing this build issue:
plugins/inputs/ah_trap/ah_trap_5020.go:6:2: "log" imported and not used plugins/inputs/ah_trap/ah_trap_5020.go:9:2: "strings" imported and not used plugins/inputs/ah_trap/ah_trap_5020.go:10:2: "strconv" imported and not used plugins/inputs/ah_trap/ah_trap_5020.go:11:2: "os/exec" imported and not used make[4]: *** [Makefile:107: telegraf] Error 1
make[3]: *** [Makefile:72: all] Error 2

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
