### PR TITLE
HOS-24315: ai-rrm not processed AP4060

### DIFF
--- a/plugins/inputs/ah_airrm/ah_airrm.go
+++ b/plugins/inputs/ah_airrm/ah_airrm.go
@@ -61,7 +61,7 @@ func getAirrmNbrTbl(ai *Ah_airrm, ifname string, cfg ieee80211req_cfg_nbr) unsaf
 
 	/* first 4 bytes is subcmd */
         switch ai.apn {
-                case "AP4020":
+                case "AP4020","AP4060":
                         cfg.cmd = AH_IEEE80211_GET_AIRRM_TBL_AP4020
                 case "AP5020":
                         cfg.cmd = AH_IEEE80211_GET_AIRRM_TBL_AP5020


### PR DESCRIPTION
value of AH_IEEE80211_GET_AIRRM_TBL was not
set for AP4060.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
