### PR TITLE
HOS-24445: ah_wireless.Gather_Client_Stat Failure

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -50,7 +50,7 @@ type Ah_wireless struct {
 	last_alarm_int          [4]alarm_int
 	last_alarm 		[4]alarm
 	last_ut_data		[4]utilization_data
-	last_clt_stat		[4][50]ah_ieee80211_sta_stats_item
+	last_clt_stat		[4][]ah_ieee80211_sta_stats_item
 	last_sq			map[string]map[int]map[int]ah_signal_quality_stats
 	wg			sync.WaitGroup
 	if_stats		[AH_MAX_WIRED]stats_interface_data
@@ -1467,6 +1467,10 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 			continue
 		}
 
+		/* Dynamically resize last_clt_stat based on number of clients connected */
+		if t.last_clt_stat[ii] == nil || len(t.last_clt_stat[ii]) != numassoc {
+			t.last_clt_stat[ii] = make([]ah_ieee80211_sta_stats_item, numassoc)
+		}
 
 		clt_item := make([]ah_ieee80211_sta_stats_item, numassoc)
 
@@ -2656,7 +2660,7 @@ func (t *Ah_wireless) Start(acc telegraf.Accumulator) error {
 	t.nw_health =	network_health_data{}
 	t.nw_service =  network_service_data{}
 
-	t.last_clt_stat = [4][50]ah_ieee80211_sta_stats_item{}
+	t.last_clt_stat = [4][]ah_ieee80211_sta_stats_item{}
 
 	return nil
 }

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -50,7 +50,7 @@ type Ah_wireless struct {
 	last_alarm_int          [4]alarm_int
 	last_alarm 		[4]alarm
 	last_ut_data		[4]utilization_data
-	last_clt_stat		[4][50]ah_ieee80211_sta_stats_item
+	last_clt_stat		[4][]ah_ieee80211_sta_stats_item
 	last_sq			map[string]map[int]map[int]ah_signal_quality_stats
 	wg			sync.WaitGroup
 	if_stats		[AH_MAX_WIRED]stats_interface_data
@@ -1464,6 +1464,10 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 			continue
 		}
 
+		/* Dynamically resize last_clt_stat based on number of clients connected */
+		if t.last_clt_stat[ii] == nil || len(t.last_clt_stat[ii]) != numassoc {
+			t.last_clt_stat[ii] = make([]ah_ieee80211_sta_stats_item, numassoc)
+		}
 
 		clt_item := make([]ah_ieee80211_sta_stats_item, numassoc)
 
@@ -2654,7 +2658,7 @@ func (t *Ah_wireless) Start(acc telegraf.Accumulator) error {
 	t.nw_health =	network_health_data{}
 	t.nw_service =  network_service_data{}
 
-	t.last_clt_stat = [4][50]ah_ieee80211_sta_stats_item{}
+	t.last_clt_stat = [4][]ah_ieee80211_sta_stats_item{}
 
 	return nil
 }


### PR DESCRIPTION
Client Stats were supported for max 50
clients. Fixed it by initializing dynamic
size.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
