### PR TITLE
HOS-24451 Add support for SSID Bind Unbind trap

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -25,6 +25,7 @@ const (
 	MAX_DESCRIBLE_LEN        = 128
 	AH_CAPWAP_STAT_NAME_MAX_LEN = 32
 	MAX_OBJ_NAME_LEN         = 4
+	AH_MSG_TRAP_SSID_BIND_UNBIND = 5
 )
 
 const (
@@ -58,6 +59,16 @@ type AhTgrafDfsTrap struct {
 	TrapId    uint8
 	IfName    [AH_MAX_TRAP_IF_NAME + 1]byte
 	Desc      [TRAP_DCRPT_LEN]byte
+}
+type AhTgrafSsidBindUnbindTrap struct {
+	TrapType    uint8
+	TrapID      uint8
+	IfName      [AH_MAX_TRAP_OBJ_NAME + 1]byte
+	IfIndex     int32
+	Description [TRAP_DCRPT_LEN]byte
+	BssidMAC    [MACADDR_LEN]byte
+	SSID        [AH_MAX_TRAP_SSID_NAME + 1]byte
+	State       uint8
 }
 
 type AhFailureTrap struct {


### PR DESCRIPTION
Added changes to format the ssid-bind-unbind trap info received from ah_telegraf to server.
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'ssidBindUnbindTrap': {'bssidMAC': '24:1F:BD:8F:E7:54', 'description': 'SSID (testing) was bound to BSSID (241f:bd8f:e754).', 'ifIndex': 24, 'ifName': 'wifi0.1', 'ssid': 'Test-ssid', 'state': BIND, 'trapId': 5, 'trapType': 103}}], 'name': 'TrapEvent', 'ts': 1768808363822}]} 