### PR TITLE
HOS-24535 Add support for Bssid Spoofing Trap

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -26,6 +26,8 @@ const (
 	AH_CAPWAP_STAT_NAME_MAX_LEN = 32
 	MAX_OBJ_NAME_LEN         = 4
 	AH_MSG_TRAP_SSID_BIND_UNBIND = 5
+	AH_MSG_TRAP_BSSID_SPOOFING = 7
+	AH_TRAP_SIZE_300	  = 300
 )
 
 const (
@@ -69,6 +71,20 @@ type AhTgrafSsidBindUnbindTrap struct {
 	BssidMAC    [MACADDR_LEN]byte
 	SSID        [AH_MAX_TRAP_SSID_NAME + 1]byte
 	State       uint8
+}
+
+type AhTgrafBSSIDSpoofingTrap struct {
+    TrapID       uint8
+    IfName      [AH_MAX_TRAP_OBJ_NAME + 1]byte
+    Description  [MAX_DESCRIBLE_LEN]byte
+    IfIndex      uint32
+    BssidMAC    [MACADDR_LEN]byte
+    AttackMAC    [MACADDR_LEN]byte
+    AttackCount  uint32
+    Protocol     uint16
+    Severity     uint8
+    SourceIP     uint32
+    TargetIP     uint32
 }
 
 type AhFailureTrap struct {


### PR DESCRIPTION
Trap :
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'bssidSpoofingTrap': {'attackCount': 1, 'attackMAC': 'AA:BB:CC:DD:EE:FF', 'bssidMAC': '24:1F:BD:8F:E7:54', 'description': 'Station aabb:ccdd:eeff is spoofing BSSID 241f:bd8f:e754.\n', 'ifIndex': 24, 'ifName': 'wifi0.1', 'protocol': 2054, 'severity': 4, 'sourceIP': '192.168.1.100', 'targetIP': '192.168.1.1', 'trapId': 105}}], 'name': 'TrapEvent', 'ts': 1769162415582}]}