### PR TITLE
HOS-24258 Add STA_OS Trap

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -404,6 +404,18 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"isClear_trapMessage_dfsBangTrap": GetTrapClearStatus(uint32(dfs.TrapType), trapBuf[:]),
 		}, nil)
 
+	case AH_MSG_TRAP_STA_OS_INFO:
+		var staos AhStaOsInfoTrap
+		copy((*[unsafe.Sizeof(staos)]byte)(unsafe.Pointer(&staos))[:], trapBuf[:unsafe.Sizeof(staos)])
+
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapId_staOsInfoTrap":  staos.TrapId,
+			"stationMac_staOsInfoTrap":  ahutil.FormatMac(staos.StaMac),
+			"osName_staOsInfoTrap":   ahutil.CleanCString(staos.Data[:]),
+			"isClear_trapMessage_staOsInfoTrap": GetTrapClearStatus(uint32(staos.TrapId), trapBuf[:]),
+                }, nil)
+
+
 	case AH_MSG_TRAP_TB:
 		var tbTrap AhTgrafTbTrap
 		copy((*[unsafe.Sizeof(tbTrap)]byte)(unsafe.Pointer(&tbTrap))[:], trapBuf[:unsafe.Sizeof(tbTrap)])
@@ -778,6 +790,19 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Ah_send_ssid_bind_unbind_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering SSID Bind Unbind trap: %v", err)
+			}
+
+		case AH_MSG_TRAP_STA_OS_INFO:
+			var staOs AhStaOsInfoTrap
+			headerLen := int(unsafe.Sizeof(staOs))
+			if len(payload) < headerLen {
+				log.Printf("[ah_trap] Invalid STA OS size: got %d, need at least %d", len(payload), headerLen)
+				continue
+			}
+			var trapBuf [256]byte
+			copy(trapBuf[:len(payload)], payload)
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering STA OS trap: %v", err)
 			}
 
 		case AH_MSG_TRAP_TB:

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -28,6 +28,7 @@ const (
 	MAX_OBJ_NAME_LEN         = 4
 	AH_MSG_TRAP_SSID_BIND_UNBIND = 5
 	AH_MSG_TRAP_BSSID_SPOOFING = 7
+	AH_MSG_TRAP_STA_OS_INFO = 8
 	AH_MSG_TRAP_TB           = 2
 	AH_TRAP_SIZE_300	  = 300
 	AH_TRAP_SIZE_256         = 256
@@ -314,6 +315,14 @@ type AhFaMvlanChangeTrap struct {
 	NativeTagged uint8
 	MgmtVlan      uint16
 	NativeVlan    uint16
+}
+
+type AhStaOsInfoTrap struct {
+        TrapId  uint8
+        DataLen uint16
+        StaMac  [MACADDR_LEN]byte
+        OsLen   uint8
+        Data    [AH_MAX_TRAP_HOST_NAME + 1]byte
 }
 
 type AhTgrafDfsTrap struct {


### PR DESCRIPTION
 
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Added a new trap to send the client os information

{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'staOsInfoTrap': {'osName': 'Linux OS', 'stationMac': '24:EE:9A:92:F7:1B', 'trapId': 106, 'trapMessage': {'isClear': False}}}], 'name': 'TrapEvent', 'ts': 1772800560963}]}

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
