### PR TITLE
 HOS-24572: Implement AH_MSG_TRAP_POE trap over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -505,22 +505,24 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 	case AH_MSG_TRAP_POE:
 		var poe AhTgrafPoeTrap
 		copy((*[unsafe.Sizeof(poe)]byte)(unsafe.Pointer(&poe))[:], trapBuf[:unsafe.Sizeof(poe)])
-
 		acc.AddFields("TrapEvent", map[string]interface{}{
-			"trapId_poeTrap":	poe.TrapID,
-			"portName_poeTrap":      ahutil.CleanCString(poe.IfName[:]),
-			"description_poeTrap":   ahutil.CleanCString(poe.Description[:]),
-			"powerMode_poeTrap":     powerModeToString(poe.PowerMode),
+			"trapId_poeStateChangeTrap": poe.TrapID,
+			"ifIndex_keys_poeStateChangeTrap": poe.IfIndex,
+			"name_keys_poeStateChangeTrap": ahutil.CleanCString(poe.IfName[:]),
+			"desc_trapMessage_poeStateChangeTrap": ahutil.CleanCString(poe.Description[:]),
+			"isClear_trapMessage_poeStateChangeTrap": GetTrapClearStatus(uint32(poe.TrapID), trapBuf[:]),
+			"new_powerClass_poeStateChangeTrap": poe.PowerClass,
 		}, nil)
 	case AH_MSG_TRAP_BOOTOS:
 		var bootos AhTgrafBootOsTrap
 		copy((*[unsafe.Sizeof(bootos)]byte)(unsafe.Pointer(&bootos))[:], trapBuf[:unsafe.Sizeof(bootos)])
 
 		acc.AddFields("TrapEvent", map[string]interface{}{
-			"trapId_bootosTrap":     bootos.TrapID,
-			"osType_bootosTrap":      osTypeToString(bootos.OsType),
-			"status_bootosTrap":      bootosStatusToString(bootos.Status),
-			"description_bootosTrap":   ahutil.CleanCString(bootos.Description[:]),
+			"trapId_bootosTrap": bootos.TrapID,
+			"osType_bootosTrap": osTypeToString(bootos.OsType),
+			"status_bootosTrap": bootosStatusToString(bootos.Status),
+			"desc_trapMessage_bootosTrap": ahutil.CleanCString(bootos.Description[:]),
+			"isClear_trapMessage_bootosTrap": GetTrapClearStatus(uint32(bootos.TrapID), trapBuf[:]),
 		}, nil)
 	}
 
@@ -564,56 +566,6 @@ func formatDevIpChangeIpv6Data(ipv6Data []AhTgrafDevIpChangeIpv6Data, count int)
 		return "[]"
 	}
 	return string(jsonBytes)
-}
-
-/*
-Helper function to convert osType value to string for bootos trap
-*/
-func osTypeToString(osType uint8) string {
-       switch osType {
-       case 0:
-               return "HOS"
-       case 1:
-               return "WiNG"
-       case 2:
-               return "WiNG-CAMP"
-       case 3:
-               return "WiNG-DIST"
-       default:
-               return fmt.Sprintf("UNKNOWN(%d)", osType)
-       }
-}
-
-/*
-Helper function to convert bootos status value to string
-*/
-func bootosStatusToString(status uint8) string {
-       switch status {
-       case 0:
-               return "Success"
-       case 1:
-               return "Failed"
-       case 2:
-               return "Legacy HW"
-       default:
-               return fmt.Sprintf("UNKNOWN(%d)", status)
-       }
-}
-
-/*
-Helper function to convert powerMode value to string
-*/
-func powerModeToString(powerMode uint8) string {
-       switch powerMode {
-       case 0:
-               return "AT"
-       case 1:
-               return "AF"
-       case 2:
-               return "BT_TYPE3"
-       default:
-               return fmt.Sprintf("UNKNOWN(%d)", powerMode)
-       }
 }
 
 /*
@@ -1039,6 +991,7 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Ah_send_generic_alarm_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering Generic Alarm trap: %v", err)
+			}
 		case AH_MSG_TRAP_POE:
 			var poe AhTgrafPoeTrap
 			expected := int(unsafe.Sizeof(poe))

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -502,6 +502,16 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"isClear_trapMessage_capwapDelayTrap": GetTrapClearStatus(uint32(capwapDelayTrap.TrapId), trapBuf[:]),
 			"severityLevel_trapMessage_capwapDelayTrap":       ahutil.CleanCString(capwapDelayTrap.Severity[:]),
 		}, nil)
+       case AH_MSG_TRAP_POE:
+               var poe AhTgrafPoeTrap
+               copy((*[unsafe.Sizeof(poe)]byte)(unsafe.Pointer(&poe))[:], trapBuf[:unsafe.Sizeof(poe)])
+
+               acc.AddFields("TrapEvent", map[string]interface{}{
+		       "trapId_poeTrap":	poe.TrapID,
+		       "portName_poeTrap":      ahutil.CleanCString(poe.IfName[:]),
+		       "description_poeTrap":   ahutil.CleanCString(poe.Description[:]),
+		       "powerMode_poeTrap":     powerModeToString(poe.PowerMode),
+	       }, nil)
 	}
 
 	return nil
@@ -544,6 +554,22 @@ func formatDevIpChangeIpv6Data(ipv6Data []AhTgrafDevIpChangeIpv6Data, count int)
 		return "[]"
 	}
 	return string(jsonBytes)
+}
+
+/*
+Helper function to convert powerMode value to string
+*/
+func powerModeToString(powerMode uint8) string {
+       switch powerMode {
+       case 0:
+               return "AT"
+       case 1:
+               return "AF"
+       case 2:
+               return "BT_TYPE3"
+       default:
+               return fmt.Sprintf("UNKNOWN(%d)", powerMode)
+       }
 }
 
 /*
@@ -969,6 +995,17 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Ah_send_generic_alarm_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering Generic Alarm trap: %v", err)
+		case AH_MSG_TRAP_POE:
+			var poe AhTgrafPoeTrap
+			expected := int(unsafe.Sizeof(poe))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid Poe size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [AH_TRAP_SIZE_256]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering Poe trap: %v", err)
 			}
 		}
 	}

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -502,16 +502,26 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"isClear_trapMessage_capwapDelayTrap": GetTrapClearStatus(uint32(capwapDelayTrap.TrapId), trapBuf[:]),
 			"severityLevel_trapMessage_capwapDelayTrap":       ahutil.CleanCString(capwapDelayTrap.Severity[:]),
 		}, nil)
-       case AH_MSG_TRAP_POE:
-               var poe AhTgrafPoeTrap
-               copy((*[unsafe.Sizeof(poe)]byte)(unsafe.Pointer(&poe))[:], trapBuf[:unsafe.Sizeof(poe)])
+	case AH_MSG_TRAP_POE:
+		var poe AhTgrafPoeTrap
+		copy((*[unsafe.Sizeof(poe)]byte)(unsafe.Pointer(&poe))[:], trapBuf[:unsafe.Sizeof(poe)])
 
-               acc.AddFields("TrapEvent", map[string]interface{}{
-		       "trapId_poeTrap":	poe.TrapID,
-		       "portName_poeTrap":      ahutil.CleanCString(poe.IfName[:]),
-		       "description_poeTrap":   ahutil.CleanCString(poe.Description[:]),
-		       "powerMode_poeTrap":     powerModeToString(poe.PowerMode),
-	       }, nil)
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapId_poeTrap":	poe.TrapID,
+			"portName_poeTrap":      ahutil.CleanCString(poe.IfName[:]),
+			"description_poeTrap":   ahutil.CleanCString(poe.Description[:]),
+			"powerMode_poeTrap":     powerModeToString(poe.PowerMode),
+		}, nil)
+	case AH_MSG_TRAP_BOOTOS:
+		var bootos AhTgrafBootOsTrap
+		copy((*[unsafe.Sizeof(bootos)]byte)(unsafe.Pointer(&bootos))[:], trapBuf[:unsafe.Sizeof(bootos)])
+
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapId_bootosTrap":     bootos.TrapID,
+			"osType_bootosTrap":      osTypeToString(bootos.OsType),
+			"status_bootosTrap":      bootosStatusToString(bootos.Status),
+			"description_bootosTrap":   ahutil.CleanCString(bootos.Description[:]),
+		}, nil)
 	}
 
 	return nil
@@ -554,6 +564,40 @@ func formatDevIpChangeIpv6Data(ipv6Data []AhTgrafDevIpChangeIpv6Data, count int)
 		return "[]"
 	}
 	return string(jsonBytes)
+}
+
+/*
+Helper function to convert osType value to string for bootos trap
+*/
+func osTypeToString(osType uint8) string {
+       switch osType {
+       case 0:
+               return "HOS"
+       case 1:
+               return "WiNG"
+       case 2:
+               return "WiNG-CAMP"
+       case 3:
+               return "WiNG-DIST"
+       default:
+               return fmt.Sprintf("UNKNOWN(%d)", osType)
+       }
+}
+
+/*
+Helper function to convert bootos status value to string
+*/
+func bootosStatusToString(status uint8) string {
+       switch status {
+       case 0:
+               return "Success"
+       case 1:
+               return "Failed"
+       case 2:
+               return "Legacy HW"
+       default:
+               return fmt.Sprintf("UNKNOWN(%d)", status)
+       }
 }
 
 /*
@@ -1007,7 +1051,19 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering Poe trap: %v", err)
 			}
-		}
+		case AH_MSG_TRAP_BOOTOS:
+			var bootos AhTgrafBootOsTrap
+			expected := int(unsafe.Sizeof(bootos))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid Bootos size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [AH_TRAP_SIZE_256]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering Bootos trap: %v", err)
+			}
+	       }
 	}
 }
 

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -31,6 +31,7 @@ const (
 	AH_MSG_TRAP_TB           = 2
 	AH_TRAP_SIZE_300	  = 300
 	AH_TRAP_SIZE_256         = 256
+	AH_MSG_TRAP_POE          = 16
 	AH_MSG_TRAP_DEV_IP_CHANGE = 17
 	AH_MSG_TRAP_CLT_CAPS = 119
 	AH_MGT0_ADDR6_NUM_MAX    = 2
@@ -498,6 +499,13 @@ type AhTelegrafCltCapsTrap struct {
 	Mfp         [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
 	Mobile      [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
 	Uapsd       [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
+}
+
+type AhTgrafPoeTrap struct {
+	TrapID          uint8
+	IfName          [MAX_OBJ_NAME_LEN]byte
+	Description     [TRAP_DCRPT_LEN]byte
+	PowerMode       uint8
 }
 
 type AhFailureTrap struct {

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -502,11 +502,13 @@ type AhTelegrafCltCapsTrap struct {
 	Uapsd       [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
 }
 
+
 type AhTgrafPoeTrap struct {
-	TrapID          uint8
-	IfName          [MAX_OBJ_NAME_LEN]byte
-	Description     [TRAP_DCRPT_LEN]byte
-	PowerMode       uint8
+       TrapID      uint8
+       IfIndex     uint8
+       PowerClass  uint8
+       IfName      [MAX_OBJ_NAME_LEN + 1]byte
+       Description [TRAP_DCRPT_LEN]byte
 }
 
 type AhTgrafBootOsTrap struct {
@@ -761,4 +763,38 @@ func GetTrapClearStatus(trapType uint32, unionData []byte) bool {
 	}
 
 	return isClear
+}
+
+/*
+Helper function to convert bootos status value to string
+*/
+func bootosStatusToString(status uint8) string {
+       switch status {
+       case 0:
+               return "SUCCESS"
+       case 1:
+               return "FAILURE"
+       case 2:
+               return "LEGACY_HW"
+	default:
+		return "UNKNOWN"
+       }
+}
+
+/*
+Helper function to convert osType value to string for bootos trap
+*/
+func osTypeToString(osType uint8) string {
+	switch osType{
+	case 0:
+		return "HOS"
+	case 1:
+		return "WiNG"
+	case 2:
+		return "WiNG_CAMP"
+	case 3:
+		return "WiNG_DIST"
+	default:
+		return "UNKNOWN"
+	}
 }

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -32,6 +32,7 @@ const (
 	AH_TRAP_SIZE_300	  = 300
 	AH_TRAP_SIZE_256         = 256
 	AH_MSG_TRAP_POE          = 16
+	AH_MSG_TRAP_BOOTOS       = 121
 	AH_MSG_TRAP_DEV_IP_CHANGE = 17
 	AH_MSG_TRAP_CLT_CAPS = 119
 	AH_MGT0_ADDR6_NUM_MAX    = 2
@@ -506,6 +507,13 @@ type AhTgrafPoeTrap struct {
 	IfName          [MAX_OBJ_NAME_LEN]byte
 	Description     [TRAP_DCRPT_LEN]byte
 	PowerMode       uint8
+}
+
+type AhTgrafBootOsTrap struct {
+	TrapID		uint8
+	OsType		uint8
+	Status		uint8
+	Description	[TRAP_DCRPT_LEN]byte
 }
 
 type AhFailureTrap struct {


### PR DESCRIPTION
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'poeTrap': {'desc': 'System power mode set to 802.3at.', 'name': 'eth0', 'powerMode': 0, 'trapId': 115}}], 'name': 'TrapEvent', 'ts': 1769619743966}]}
192.168.1.219 - - [28/Jan/2026 22:32:24] "POST /telegraf/rest/v1 HTTP/1.1" 200 -