### PR TITLE
HOS-24464 Send client stats in one metric

### DIFF
--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -1428,7 +1428,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 	var client_mac string
 	ii = 0
 
-
+    currentTime := time.Now()
     for _, intfName2 := range t.Ifname {
 
 		var cltstat ah_ieee80211_get_wifi_sta_stats
@@ -1901,7 +1901,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 				fields2[bucket]				= i
 			}
 
-			acc.AddFields("ClientStats", fields2, tags, time.Now())
+			acc.AddFields("ClientStats", fields2, tags, currentTime)
 
 
 			clt_new_stats := saved_stats{}

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -1425,7 +1425,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 	var client_mac string
 	ii = 0
 
-
+    currentTime := time.Now()
     for _, intfName2 := range t.Ifname {
 
 		var cltstat ah_ieee80211_get_wifi_sta_stats
@@ -1899,7 +1899,7 @@ func Gather_Client_Stat(t *Ah_wireless, acc telegraf.Accumulator) error {
 				fields2[bucket]				= i
 			}
 
-			acc.AddFields("ClientStats", fields2, tags, time.Now())
+			acc.AddFields("ClientStats", fields2, tags, currentTime)
 
 
 			clt_new_stats := saved_stats{}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Add the timeStamp manaully to send all the clients in single metric

<img width="857" height="652" alt="image" src="https://github.com/user-attachments/assets/63289604-94c9-4b10-81b2-9f2caf6591e0" />




## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
