### PR TITLE
HOS-24682 : Implement AH_MSG_TRAP_DEV_IP_CHANGE trap over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -28,6 +28,9 @@ const (
 	AH_MSG_TRAP_SSID_BIND_UNBIND = 5
 	AH_MSG_TRAP_BSSID_SPOOFING = 7
 	AH_TRAP_SIZE_300	  = 300
+	AH_TRAP_SIZE_256         = 256
+	AH_MSG_TRAP_DEV_IP_CHANGE = 17
+	AH_MGT0_ADDR6_NUM_MAX    = 2
 )
 
 const (
@@ -85,6 +88,25 @@ type AhTgrafBSSIDSpoofingTrap struct {
     Severity     uint8
     SourceIP     uint32
     TargetIP     uint32
+}
+
+type AhTgrafDevIpChangeIpv6Data struct {
+	Ipv6AddrType       uint8
+	_                  [3]byte
+	Ipv6Addr           [16]byte
+	Ipv6Prefix         uint32
+	Ipv6DefaultGateway [16]byte
+}
+
+type AhTgrafDevIpChangeTrap struct {
+	TrapType           uint8
+	_                  [3]byte
+	Ipv4Addr           uint32
+	Ipv4Netmask        uint32
+	Ipv4DefaultGateway uint32
+	Ipv6AddrNum        uint8
+	_                  [3]byte
+	Ipv6Data           [AH_MGT0_ADDR6_NUM_MAX]AhTgrafDevIpChangeIpv6Data
 }
 
 type AhFailureTrap struct {


### PR DESCRIPTION
Trap Output:
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'devIpChangeTrap': {'ipv4Addr': '192.168.1.219', 'ipv4DefaultGateway': '192.168.1.1', 'ipv4Netmask': '255.255.255.0', 'ipv6AddrNum': 2, 'ipv6Data': '[{"ipv6Addr":"2008::1","ipv6AddrType":1,"ipv6DefaultGateway":"fe80::a806:82a0:ab96:701a","ipv6Prefix":64},{"ipv6Addr":"fe80::261f:bdff:fe8f:e740","ipv6AddrType":2,"ipv6DefaultGateway":"fe80::a806:82a0:ab96:701a","ipv6Prefix":64}]', 'trapType': 116}}], 'name': 'TrapEvent', 'ts': 1770622137725}]}
192.168.1.219 - - [09/Feb/2026 12:59:38] "POST /telegraf/rest/v1 HTTP/1.1" 200 -