### PR TITLE
HOS-24500 Implement AH_MSG_DHCP_OPTION55 over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -357,6 +357,22 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"systemId_faMvlanTrap":           fmt.Sprintf("%X", mvlan.SystemID),
 		}, nil)
 
+	case AH_MSG_TRAP_DHCP_OPTION55:
+		var dhcp AhDhcpOption55Trap
+		copy((*[unsafe.Sizeof(dhcp)]byte)(unsafe.Pointer(&dhcp))[:], trapBuf[:unsafe.Sizeof(dhcp)])
+		optLen := int(dhcp.Opt55Len)
+		if optLen < 0 {
+			optLen = 0
+		}
+		if optLen > len(dhcp.Data) {
+			optLen = len(dhcp.Data)
+		}
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapType_dhcpOption55Trap":  dhcp.TrapId,
+			"staMac_dhcpOption55Trap":    ahutil.FormatMac(dhcp.StaMac),
+			"option55_dhcpOption55Trap":  ahutil.CleanCString(dhcp.Data[:optLen]),
+		}, nil)
+
 	case AH_MSG_TRAP_DFS_BANG:
 		var dfs AhTgrafDfsTrap
 		copy((*[unsafe.Sizeof(dfs)]byte)(unsafe.Pointer(&dfs))[:], trapBuf[:unsafe.Sizeof(dfs)])
@@ -543,6 +559,20 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			if err := t.Ah_send_sta_leave_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering STA LEAVE STATS trap: %v", err)
 			}
+
+		case AH_MSG_TRAP_DHCP_OPTION55:
+			var dhcp AhDhcpOption55Trap
+			expected := int(unsafe.Sizeof(dhcp))
+			if len(payload) < expected {
+				log.Printf("[ah_trap] Invalid DHCP OPTION55 size: got %d, expected at least %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [256]byte
+			copy(trapBuf[:expected], payload[:expected])
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering DHCP OPTION55 trap: %v", err)
+			}
+
 		case AH_MSG_TRAP_SSID_BIND_UNBIND:
 			var  SsidBindUnbind AhTgrafSsidBindUnbindTrap
 			expected := int(unsafe.Sizeof(SsidBindUnbind))

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -368,7 +368,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			optLen = len(dhcp.Data)
 		}
 		acc.AddFields("TrapEvent", map[string]interface{}{
-			"trapType_dhcpOption55Trap":  dhcp.TrapId,
+			"trapId_dhcpOption55Trap":  dhcp.TrapId,
 			"staMac_dhcpOption55Trap":    ahutil.FormatMac(dhcp.StaMac),
 			"option55_dhcpOption55Trap":  ahutil.CleanCString(dhcp.Data[:optLen]),
 		}, nil)

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -367,10 +367,18 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 		if optLen > len(dhcp.Data) {
 			optLen = len(dhcp.Data)
 		}
+		
+		option := map[string]interface{}{
+			"code":  55,
+			"value": optionValue,
+		}
+
+		optionJSON, _ := json.Marshal(option)
+
 		acc.AddFields("TrapEvent", map[string]interface{}{
-			"trapId_dhcpOption55Trap":  dhcp.TrapId,
-			"staMac_dhcpOption55Trap":    ahutil.FormatMac(dhcp.StaMac),
-			"option55_dhcpOption55Trap":  ahutil.CleanCString(dhcp.Data[:optLen]),
+			"trapId_dhcpOptionTrap":     dhcp.TrapId,
+			"stationMac_dhcpOptionTrap": ahutil.FormatMac(dhcp.StaMac),
+			"option_dhcpOptionTrap":     string(optionJSON),
 		}, nil)
 
 	case AH_MSG_TRAP_DFS_BANG:

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -21,6 +21,7 @@ const (
 	TRAP_DCRPT_LEN           = 96
 	AH_MSG_TRAP_DFS_BANG     = 12
 	AH_MSG_TRAP_STA_LEAVE_STATS = 6
+	AH_MSG_TRAP_DHCP_OPTION55   = 123
 	MACADDR_LEN              = 6
 	MAX_DESCRIBLE_LEN        = 128
 	AH_CAPWAP_STAT_NAME_MAX_LEN = 32
@@ -74,6 +75,14 @@ type AhTgrafSsidBindUnbindTrap struct {
 	BssidMAC    [MACADDR_LEN]byte
 	SSID        [AH_MAX_TRAP_SSID_NAME + 1]byte
 	State       uint8
+}
+
+type AhDhcpOption55Trap struct {
+	TrapId   uint8
+	DataLen  uint16
+    StaMac  [6]uint8
+	Opt55Len uint8
+    Data    [0]uint8
 }
 
 type AhTgrafBSSIDSpoofingTrap struct {


### PR DESCRIPTION
## Summary
<!-- Mandatory-->

Added a new trap to send the client os information
{'trapEvent': [{'device': {'serialnumber': 'HA012235Y-10251'}, 'items': [{'dhcpOption55Trap': {'option55': '3,6,15', 'staMac': '11:22:33:44:55:08', 'trapId': 122}}], 'name': 'TrapEvent', 'ts': 1770999774785}]}}

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
