### PR TITLE
HOS-24784 Add clear param for set or clear trap

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -82,6 +82,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
 			"severityLevel_trapMessage_failureTrap": trap.Level,
 			"msgId_trapMessage_failureTrap": trap.MsgID,
 			"desc_trapMessage_failureTrap":  ahutil.CleanCString(trap.Desc[:]),
+			"clear_trapMessage_failureTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
 		}, nil)
 
 	case AH_THRESHOLD_TRAP_TYPE:
@@ -97,6 +98,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
 			"severityLevel_trapMessage_thresholdTrap": trap.Level,
 			"msgId_trapMessage_thresholdTrap": trap.MsgID,
 			"desc_trapMessage_thresholdTrap":  ahutil.CleanCString(trap.Desc[:]),
+			"clear_trapMessage_thresholdTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
 		}, nil)
 
         case AH_STATE_CHANGE_TRAP_TYPE:
@@ -112,7 +114,8 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_stateChangeTrap": trap.Level,
                         "msgId_trapMessage_stateChangeTrap": trap.MsgID,
                         "desc_trapMessage_stateChangeTrap":  ahutil.CleanCString(trap.Desc[:]),
-                }, nil)
+                        "clear_trapMessage_stateChangeTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
+				}, nil)
 
 	 case AH_CONNECTION_CHANGE_TRAP_TYPE:
                 var ahconnectionchange AhConnectionChangeTrap
@@ -142,6 +145,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_idpApEventTrap": trap.Level,
                         "msgId_trapMessage_idpApEventTrap": trap.MsgID,
                         "desc_trapMessage_idpApEventTrap":  ahutil.CleanCString(trap.Desc[:]),
+                        "clear_trapMessage_idpApEventTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                 }, nil)
 
 	case AH_CLIENT_INFO_TRAP_TYPE:
@@ -162,6 +166,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_clientInfoTrap": trap.Level,
                         "msgId_trapMessage_clientInfoTrap": trap.MsgID,
                         "desc_trapMessage_clientInfoTrap":  ahutil.CleanCString(trap.Desc[:]),
+                        "clear_trapMessage_clientInfoTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                 }, nil)
 
          case AH_POWER_INFO_TRAP_TYPE:
@@ -184,6 +189,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
 			"severityLevel_trapMessage_powerInfoTrap":  trap.Level,
                         "msgId_trapMessage_powerInfoTrap":  trap.MsgID,
 			"desc_trapMessage_powerInfoTrap":   ahutil.CleanCString(trap.Desc[:]),
+			"clear_trapMessage_powerInfoTrap":  GetTrapClearStatus(trap.TrapType, trap.Union[:]),
 			}, nil)
 
 	case AH_CHANNEL_POWER_TRAP_TYPE:
@@ -205,6 +211,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_channelPowerTrap":  trap.Level,
                         "msgId_trapMessage_channelPowerTrap":  trap.MsgID,
                         "desc_trapMessage_channelPowerTrap":   ahutil.CleanCString(trap.Desc[:]),
+                        "clear_trapMessage_channelPowerTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	case AH_IDP_MITIGATE_TRAP_TYPE:
@@ -223,6 +230,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_idpMitigateTrap":  trap.Level,
                         "msgId_trapMessage_idpMitigateTrap":  trap.MsgID,
                         "desc_trapMessage_idpMitigateTrap":   ahutil.CleanCString(trap.Desc[:]),
+                        "clear_trapMessage_idpMitigateTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	case AH_INTERFERENCE_ALERT_TRAP_TYPE:
@@ -243,6 +251,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_interferenceAlertTrap":   trap.Level,
                         "msgId_trapMessage_interferenceAlertTrap":   trap.MsgID,
                         "desc_trapMessage_interferenceAlertTrap":    ahutil.CleanCString(trap.Desc[:]),
+                        "clear_trapMessage_interferenceAlertTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	case AH_BW_SENTINEL_TRAP_TYPE:
@@ -265,6 +274,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_bwSentinelTrap":   trap.Level,
                         "msgId_trapMessage_bwSentinelTrap":   trap.MsgID,
                         "desc_trapMessage_bwSentinelTrap":    ahutil.CleanCString(trap.Desc[:]),
+                        "clear_trapMessage_bwSentinelTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	case AH_ALARM_ALRT_TRAP_TYPE:
@@ -286,6 +296,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_alarmAlertTrap":   trap.Level,
                         "msgId_trapMessage_alarmAlertTrap":   trap.MsgID,
                         "desc_trapMessage_alarmAlertTrap":    ahutil.CleanCString(trap.Desc[:]),
+                        "clear_trapMessage_alarmAlertTrap":   GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	case AH_MESH_MGT0_VLAN_CHANGE_TRAP_TYPE:
@@ -302,6 +313,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "severityLevel_trapMessage_meshMgt0vlanChangeTrap":   trap.Level,
                         "msgId_trapMessage_meshMgt0vlanChangeTrap":   trap.MsgID,
                         "desc_trapMessage_meshMgt0vlanChangeTrap":    ahutil.CleanCString(trap.Desc[:]),
+						"clear_trapMessage_meshMgt0vlanChangeTrap":   GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	case AH_MESH_STABLE_STAGE_TRAP_TYPE:
@@ -316,6 +328,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "level_trapMessage_meshStableStageTrap":   trap.Level,
                         "msgId_trapMessage_meshStableStageTrap":   trap.MsgID,
                         "desc_trapMessage_meshStableStageTrap":    ahutil.CleanCString(trap.Desc[:]),
+						"clear_trapMessage_meshStableStageTrap":   GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	case AH_KEY_FULL_ALARM_TRAP_TYPE:
@@ -332,6 +345,7 @@ func (t *TrapPlugin) Gather_Ah_Logen(trap AhTrapMsg, acc telegraf.Accumulator) e
                         "level_trapMessage_keyFullAlarmTrap":   trap.Level,
                         "msgId_trapMessage_keyFullAlarmTrap":   trap.MsgID,
                         "desc_trapMessage_keyFullAlarmTrap":    ahutil.CleanCString(trap.Desc[:]),
+						"clear_trapMessage_keyFullAlarmTrap":   GetTrapClearStatus(trap.TrapType, trap.Union[:]),
                         }, nil)
 
 	}
@@ -355,6 +369,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"nativeVlan_faMvlanTrap":         mvlan.NativeVlan,
 			"nativeTagged_faMvlanTrap":       mvlan.NativeTagged,
 			"systemId_faMvlanTrap":           fmt.Sprintf("%X", mvlan.SystemID),
+			"clear_faMvlanTrap":  GetTrapClearStatus(uint32(mvlan.TrapType), trapBuf[:]),
 		}, nil)
 
 	case AH_MSG_TRAP_DFS_BANG:
@@ -366,6 +381,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"trapId_dfsBangTrap":      dfs.TrapId,
 			"name_dfsBangTrap":        ahutil.CleanCString(dfs.IfName[:]),
 			"desc_dfsBangTrap":        ahutil.CleanCString(dfs.Desc[:]),
+			"clear_dfsBangTrap": GetTrapClearStatus(uint32(dfs.TrapType), trapBuf[:]),
 		}, nil)
 
 	case AH_MSG_TRAP_DEV_IP_CHANGE:
@@ -385,6 +401,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"ipv4DefaultGateway_devIpChangeTrap": ahutil.IntToIpv4(devIpChange.Ipv4DefaultGateway),
 			"ipv6AddrNum_devIpChangeTrap":       devIpChange.Ipv6AddrNum,
 			"ipv6Data_devIpChangeTrap":          formatDevIpChangeIpv6Data(devIpChange.Ipv6Data[:], int(devIpChange.Ipv6AddrNum)),
+			"clear_devIpChangeTrap":             GetTrapClearStatus(uint32(devIpChange.TrapType), trapBuf[:]),
 		}, nil)
 	}
 
@@ -440,6 +457,7 @@ func (t *TrapPlugin) Ah_send_ssid_bind_unbind_trap(trapType uint32, trapBuf [600
         "bssidMac_ssidBindUnbindTrap":    ahutil.FormatMac(ssidBindUnbind.BssidMAC),
         "ssid_ssidBindUnbindTrap":        ahutil.CleanCString(ssidBindUnbind.SSID[:]),
 	"state_ssidBindUnbindTrap":       stateToString(ssidBindUnbind.State),
+	"clear_ssidBindUnbindTrap":       GetTrapClearStatus(uint32(ssidBindUnbind.TrapType), trapBuf[:]),
     }, nil)
     return nil
 }
@@ -460,6 +478,7 @@ func (t *TrapPlugin) Ah_send_bssid_spoofing_trap(trapType uint32, trapBuf [AH_TR
         "severity_bssidSpoofingTrap":     bssidSpoofing.Severity,
         "sourceIp_bssidSpoofingTrap":     ahutil.IntToIpv4(bssidSpoofing.SourceIP),
         "targetIp_bssidSpoofingTrap":     ahutil.IntToIpv4(bssidSpoofing.TargetIP),
+        "clear_bssidSpoofingTrap":        GetTrapClearStatus(trapType, trapBuf[:]),
     }, nil)
     return nil
 }

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -369,7 +369,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"nativeVlan_faMvlanTrap":         mvlan.NativeVlan,
 			"nativeTagged_faMvlanTrap":       mvlan.NativeTagged,
 			"systemId_faMvlanTrap":           fmt.Sprintf("%X", mvlan.SystemID),
-			"clear_faMvlanTrap":  GetTrapClearStatus(uint32(mvlan.TrapType), trapBuf[:]),
+			"clear_trapMessage_faMvlanTrap":  GetTrapClearStatus(uint32(mvlan.TrapType), trapBuf[:]),
 		}, nil)
 
 	case AH_MSG_TRAP_DFS_BANG:
@@ -381,7 +381,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"trapId_dfsBangTrap":      dfs.TrapId,
 			"name_dfsBangTrap":        ahutil.CleanCString(dfs.IfName[:]),
 			"desc_dfsBangTrap":        ahutil.CleanCString(dfs.Desc[:]),
-			"clear_dfsBangTrap": GetTrapClearStatus(uint32(dfs.TrapType), trapBuf[:]),
+			"clear_trapMessage_dfsBangTrap": GetTrapClearStatus(uint32(dfs.TrapType), trapBuf[:]),
 		}, nil)
 
 	case AH_MSG_TRAP_DEV_IP_CHANGE:
@@ -401,7 +401,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"ipv4DefaultGateway_devIpChangeTrap": ahutil.IntToIpv4(devIpChange.Ipv4DefaultGateway),
 			"ipv6AddrNum_devIpChangeTrap":       devIpChange.Ipv6AddrNum,
 			"ipv6Data_devIpChangeTrap":          formatDevIpChangeIpv6Data(devIpChange.Ipv6Data[:], int(devIpChange.Ipv6AddrNum)),
-			"clear_devIpChangeTrap":             GetTrapClearStatus(uint32(devIpChange.TrapType), trapBuf[:]),
+			"clear_trapMessage_devIpChangeTrap": GetTrapClearStatus(uint32(devIpChange.TrapType), trapBuf[:]),
 		}, nil)
 	}
 
@@ -457,7 +457,7 @@ func (t *TrapPlugin) Ah_send_ssid_bind_unbind_trap(trapType uint32, trapBuf [600
         "bssidMac_ssidBindUnbindTrap":    ahutil.FormatMac(ssidBindUnbind.BssidMAC),
         "ssid_ssidBindUnbindTrap":        ahutil.CleanCString(ssidBindUnbind.SSID[:]),
 	"state_ssidBindUnbindTrap":       stateToString(ssidBindUnbind.State),
-	"clear_ssidBindUnbindTrap":       GetTrapClearStatus(uint32(ssidBindUnbind.TrapType), trapBuf[:]),
+	"clear_trapMessage_ssidBindUnbindTrap":       GetTrapClearStatus(uint32(ssidBindUnbind.TrapType), trapBuf[:]),
     }, nil)
     return nil
 }
@@ -478,7 +478,7 @@ func (t *TrapPlugin) Ah_send_bssid_spoofing_trap(trapType uint32, trapBuf [AH_TR
         "severity_bssidSpoofingTrap":     bssidSpoofing.Severity,
         "sourceIp_bssidSpoofingTrap":     ahutil.IntToIpv4(bssidSpoofing.SourceIP),
         "targetIp_bssidSpoofingTrap":     ahutil.IntToIpv4(bssidSpoofing.TargetIP),
-        "clear_bssidSpoofingTrap":        GetTrapClearStatus(trapType, trapBuf[:]),
+        "clear_trapMessage_bssidSpoofingTrap":        GetTrapClearStatus(trapType, trapBuf[:]),
     }, nil)
     return nil
 }

--- a/plugins/inputs/ah_trap/ah_trap_5020.go
+++ b/plugins/inputs/ah_trap/ah_trap_5020.go
@@ -130,6 +130,7 @@ func (t *TrapPlugin) Ah_send_sta_leave_trap(trapType uint32, trapBuf [600]byte, 
 		"ts_staLeaveStatsTrap":				staLeave.Ts,
 		"staAddr6Num_staLeaveStatsTrap":	staLeave.StaAddr6Num,
 		"staAddr6_staLeaveStatsTrap":		IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)),
+		"clear_trapMessage_staLeaveStatsTrap": GetTrapClearStatus(trapType, trapBuf[:]),
 	}, nil)
 	return nil
 }

--- a/plugins/inputs/ah_trap/ah_trap_all.go
+++ b/plugins/inputs/ah_trap/ah_trap_all.go
@@ -120,6 +120,7 @@ func (t *TrapPlugin) Ah_send_sta_leave_trap(trapType uint32, trapBuf [600]byte, 
 		"staAddr6_staLeaveStatsTrap":		IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)),
 		"eventreasoncode_staLeaveStatsTrap":	staLeave.EventReasonCode,
 		"eventtype_staLeaveStatsTrap":		staLeave.EventType,
+		"clear_trapMessage_staLeaveStatsTrap": GetTrapClearStatus(trapType, trapBuf[:]),
 	}, nil)
 	return nil
 }

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -2,6 +2,7 @@ package ah_trap
 
 import (
 	"net"
+	"unsafe"
 )
 
 type AhTrapType uint32
@@ -31,6 +32,10 @@ const (
 	AH_TRAP_SIZE_256         = 256
 	AH_MSG_TRAP_DEV_IP_CHANGE = 17
 	AH_MGT0_ADDR6_NUM_MAX    = 2
+	AH_SNMP_TRUE             = 1
+	AH_SNMP_FALSE            = 2
+	AH_MSG_TRAP_SET          = 0
+	AH_MSG_TRAP_CLEAR        = 1
 )
 
 const (
@@ -285,4 +290,52 @@ func IntToIPv6_1(addrs []AhStaAddr6, count int) []string {
 type AhStaAddr6 struct {
 	AddrType byte      // char addr_type
 	StaAddr6 [16]byte  // struct in6_addr (IPv6 address is 16 bytes)
+}
+
+// GetTrapClearStatus extracts clear status from trap based on trap type and set field
+// Mimics ah_get_msg_trap_type_clear() from syslogd.c
+// Returns: 0 = SET (alarm raised), 1 = CLEAR (alarm cleared)
+func GetTrapClearStatus(trapType uint32, unionData []byte) uint8 {
+	clear := uint8(0) // Default: SET
+
+	switch AhTrapType(trapType) {
+	case AH_FAILURE_TRAP_TYPE:
+		var failure AhFailureTrap
+		if len(unionData) >= int(unsafe.Sizeof(failure)) {
+			copy((*[1 << 10]byte)(unsafe.Pointer(&failure))[:unsafe.Sizeof(failure)], unionData)
+			if failure.Set == AH_SNMP_TRUE {
+				clear = AH_MSG_TRAP_SET
+			} else {
+				clear = AH_MSG_TRAP_CLEAR
+			}
+		}
+
+	case AH_INTERFERENCE_ALERT_TRAP_TYPE:
+		var interference AhInterferenceAlertTrap
+		if len(unionData) >= int(unsafe.Sizeof(interference)) {
+			copy((*[1 << 10]byte)(unsafe.Pointer(&interference))[:unsafe.Sizeof(interference)], unionData)
+			if interference.Set == AH_SNMP_TRUE {
+				clear = AH_MSG_TRAP_SET
+			} else {
+				clear = AH_MSG_TRAP_CLEAR
+			}
+		}
+
+	case AH_ALARM_ALRT_TRAP_TYPE:
+		var alarmAlert AhAlarmAlrtTrap
+		if len(unionData) >= int(unsafe.Sizeof(alarmAlert)) {
+			copy((*[1 << 10]byte)(unsafe.Pointer(&alarmAlert))[:unsafe.Sizeof(alarmAlert)], unionData)
+			if alarmAlert.Set == AH_SNMP_TRUE {
+				clear = AH_MSG_TRAP_SET
+			} else {
+				clear = AH_MSG_TRAP_CLEAR
+			}
+		}
+
+	default:
+		// Event traps always return SET (0)
+		clear = 0
+	}
+
+	return clear
 }

--- a/plugins/inputs/ah_trap/ah_trap_handler_base.go
+++ b/plugins/inputs/ah_trap/ah_trap_handler_base.go
@@ -48,5 +48,6 @@ func gatherConnectionChangeTrap(ahconnectionchange AhConnectionChangeTrap, trap 
 		"severityLevel_trapMessage_connectionChangeTrap": trap.Level,
 		"msgId_trapMessage_connectionChangeTrap": trap.MsgID,
 		"desc_trapMessage_connectionChangeTrap":  ahutil.CleanCString(trap.Desc[:]),
+		"clear_trapMessage_connectionChangeTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
 	}, nil)
 }

--- a/plugins/inputs/ah_trap/ah_trap_handler_mlo.go
+++ b/plugins/inputs/ah_trap/ah_trap_handler_mlo.go
@@ -55,5 +55,6 @@ func gatherConnectionChangeTrap(ahconnectionchange AhConnectionChangeTrap, trap 
 		"severityLevel_trapMessage_connectionChangeTrap": trap.Level,
 		"msgId_trapMessage_connectionChangeTrap": trap.MsgID,
 		"desc_trapMessage_connectionChangeTrap":  ahutil.CleanCString(trap.Desc[:]),
+		"clear_trapMessage_connectionChangeTrap": GetTrapClearStatus(trap.TrapType, trap.Union[:]),
 	}, nil)
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Added new parameter name clear to know if the trap initiated is a set or clear 
trap

{'trapEvent': [{'device': {'serialnumber': 'WF042513S-C0067'}, 'items': [{'failureTrap': {'cause': 3, 'set': 2, 'trapMessage': {**'clear': 1**, 'desc': 'fan failure.\n', 'msgId': 1, 'severityLevel': 5}, 'trapObjName': 'fan 1'}}], 'name': 'TrapEvent', 'ts': 1771227551695}]}

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
