### PR TITLE
HOS-24795 IP address is update in reverse format in connection change trap

### DIFF
--- a/plugins/common/ahutil/ahutil.go
+++ b/plugins/common/ahutil/ahutil.go
@@ -522,10 +522,10 @@ func GetSSIDbyIfName(ifName string) (ssid string, err error) {
 func IntToIpv4(num uint32) string {
 
     b := make([]byte, 4)
-    b[0] = byte(num)
-    b[1] = byte(num >> 8)
-    b[2] = byte(num >> 16)
-    b[3] = byte(num >> 24)
+    b[0] = byte(num >> 24)
+    b[1] = byte(num >> 16)
+    b[2] = byte(num >> 8)
+    b[3] = byte(num)
     return fmt.Sprintf("%d.%d.%d.%d",b[0],b[1],b[2],b[3])
 }
 

--- a/plugins/common/ahutil/ahutil.go
+++ b/plugins/common/ahutil/ahutil.go
@@ -522,10 +522,10 @@ func GetSSIDbyIfName(ifName string) (ssid string, err error) {
 func IntToIpv4(num uint32) string {
 
     b := make([]byte, 4)
-    b[0] = byte(num >> 24)
-    b[1] = byte(num >> 16)
-    b[2] = byte(num >> 8)
-    b[3] = byte(num)
+    b[0] = byte(num)
+    b[1] = byte(num >> 8)
+    b[2] = byte(num >> 16)
+    b[3] = byte(num >> 24)
     return fmt.Sprintf("%d.%d.%d.%d",b[0],b[1],b[2],b[3])
 }
 

--- a/plugins/inputs/ah_trap/ah_trap_handler_base.go
+++ b/plugins/inputs/ah_trap/ah_trap_handler_base.go
@@ -18,7 +18,7 @@ func gatherConnectionChangeTrap(ahconnectionchange AhConnectionChangeTrap, trap 
 		"remoteId_connectionChangeTrap":          ahutil.FormatMac(ahconnectionchange.RemoteID),
 		"bssid_connectionChangeTrap":             ahutil.FormatMac(ahconnectionchange.BSSID),
 		"curState_connectionChangeTrap":          ahconnectionchange.CurState,
-		"clientIp_connectionChangeTrap":          ahutil.IntToIpv4(ahconnectionchange.ClientIP),
+		"clientIp_connectionChangeTrap":          intToIPv4(ahconnectionchange.ClientIP),
 		"clientAuthMethod_connectionChangeTrap":  ahconnectionchange.ClientAuthMethod,
 		"clientEncryptMethod_connectionChangeTrap": ahconnectionchange.ClientEncryptMethod,
 		"clientMacProto_connectionChangeTrap":    ahconnectionchange.ClientMacProto,

--- a/plugins/inputs/ah_trap/ah_trap_handler_mlo.go
+++ b/plugins/inputs/ah_trap/ah_trap_handler_mlo.go
@@ -18,7 +18,7 @@ func gatherConnectionChangeTrap(ahconnectionchange AhConnectionChangeTrap, trap 
 		"remoteId_connectionChangeTrap":          ahutil.FormatMac(ahconnectionchange.RemoteID),
 		"bssid_connectionChangeTrap":             ahutil.FormatMac(ahconnectionchange.BSSID),
 		"curState_connectionChangeTrap":          ahconnectionchange.CurState,
-		"clientIp_connectionChangeTrap":          ahutil.IntToIpv4(ahconnectionchange.ClientIP),
+		"clientIp_connectionChangeTrap":          intToIPv4(ahconnectionchange.ClientIP),
 		"clientAuthMethod_connectionChangeTrap":  ahconnectionchange.ClientAuthMethod,
 		"clientEncryptMethod_connectionChangeTrap": ahconnectionchange.ClientEncryptMethod,
 		"clientMacProto_connectionChangeTrap":    ahconnectionchange.ClientMacProto,


### PR DESCRIPTION
… trap

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
  

AP side observation:

AP4020_blr3_1#sh station
Chan=channel number; Pow=Power in dBm;
A-Mode=Authentication mode; Cipher=Encryption mode;
A-Time=Associated time; Auth=Authenticated;
UPID=User profile Identifier; Phymode=Physical mode;
 
Ifname=wifi0.1, Ifindex=32, SSID=Harshith_testing:
Mac Addr       IP Addr          Chan   Tx Rate Rx Rate Pow(SNR)         A-Mode   Cipher  A-Time  VLAN Auth UPID Phymode LDPC Tx-STBC Rx-STBC    SM-PS Chan-width   MU-MIMO Release Station-State             MLO
-------------- --------------- ------- ------- ------- -------- -------------- -------- -------- ---- ---- ---- ------- ---- ------- ------- -------- ---------- --------- ------- -------------           --------
9c67:d659:e39f 10.234.162.233    1      270.8M  243.8M  -19(74)           open     none 00:00:26    1  Yes    0 11ax-2g  Yes    No      No     static    20MHz          No      No data collecting...       No

Serverside observation:

[INGEST] {"trapEvent":[{"device":{"serialnumber":"WF012503S-P0048"},"items":[{"connectionChangeTrap":{"apLinkAddr":"00:00:00:00:00:00","assocTime":15,"associationTime":1771575792,"authTime":3,"authUsed":2,"band":0,"bssid":"18:49:F8:C9:52:54","clientAssocBitmap":0,"clientAuthMethod":1,"clientChannel":11,"clientCwpUsed":2,"clientEncryptMethod":3,"clientIp":"10.234.162.233","clientMacProto":6,"clientMode":0,"clientUpId":0,"clientVlan":1,"curState":1,"deauthReason":0,"hostName":"DESKTOP-MQN7EBS","isMloAssoc":0,"keys":{"ifIndex":34,"name":"wifi0.1"},"mgtStatus":0,"negotiateKbps":270830,"objectType":1,"option55":"","os":"","profile":"default-profile","radioProfile":"radio_11be-2g","remoteId":"9C:67:D6:59:E3:9F","roamTime":-1,"rssi":76,"snr":-17,"ssid":"Harshith_testing","staAddr6":"","staAddr6Num":0,"staLinkAddr":"00:00:00:00:00:00","staMldAddr":"00:00:00:00:00:00","trapMessage":{"desc":"Station 9c67:d659:e39f was authenticated on 1849:f8c9:5254 through SSID Harshith_testing vid 1.\n","isClear":false,"msgId":1,"severityLevel":"INFO"},"trapObjName":"AUTH","userName":""}}],"name":"TrapEvent","ts":1771575793174}]}
 


