### PR TITLE
HOS-24820 : Implement AH_MSG_TRAP_CLT_CAPS trap over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -421,6 +421,29 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"ipv6Data_devIpChangeTrap":          formatDevIpChangeIpv6Data(devIpChange.Ipv6Data[:], int(devIpChange.Ipv6AddrNum)),
 			"isClear_trapMessage_devIpChangeTrap": GetTrapClearStatus(uint32(devIpChange.TrapType), trapBuf[:]),
 		}, nil)
+	case AH_MSG_TRAP_CLT_CAPS:
+		var cltCaps AhTelegrafCltCapsTrap
+		copy((*[unsafe.Sizeof(cltCaps)]byte)(unsafe.Pointer(&cltCaps))[:], trapBuf[:unsafe.Sizeof(cltCaps)])
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapType_clientCapabilitiesTrap":    cltCaps.TrapType,
+			"clientMac_clientCapabilitiesTrap":   ahutil.FormatMac(cltCaps.CltMac),
+			"bssidMac_clientCapabilitiesTrap":    ahutil.FormatMac(cltCaps.BssidMac),
+			"channel_clientCapabilitiesTrap":     cltCaps.Channel,
+			"frameType_clientCapabilitiesTrap":   ahutil.CleanCString(cltCaps.Type[:]),
+			"bandWidth_clientCapabilitiesTrap":   ahutil.CleanCString(cltCaps.Bw[:]),
+			"nss_clientCapabilitiesTrap":         cltCaps.Nss,
+			"phyMode_clientCapabilitiesTrap":     ahutil.CleanCString(cltCaps.Mode[:]),
+			"minTxPower_clientCapabilitiesTrap":  cltCaps.MinTxPower,
+			"maxTxPower_clientCapabilitiesTrap":  cltCaps.MaxTxPower,
+			"muMimo_clientCapabilitiesTrap":      ahutil.CleanCString(cltCaps.MuMimo[:]),
+			"wmm_clientCapabilitiesTrap":         ahutil.CleanCString(cltCaps.Wmm[:]),
+			"cipher_clientCapabilitiesTrap":      ahutil.CleanCString(cltCaps.Cipher[:]),
+			"akm_clientCapabilitiesTrap":         ahutil.CleanCString(cltCaps.Akm[:]),
+			"mfp_clientCapabilitiesTrap":         ahutil.CleanCString(cltCaps.Mfp[:]),
+			"mobility_clientCapabilitiesTrap":    ahutil.CleanCString(cltCaps.Mobile[:]),
+			"uapsd_clientCapabilitiesTrap":       ahutil.CleanCString(cltCaps.Uapsd[:]),
+			"isClear_trapMessage_clientCapabilitiesTrap": GetTrapClearStatus(uint32(cltCaps.TrapType), trapBuf[:]),
+		}, nil)
 	}
 
 	return nil
@@ -631,6 +654,18 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering DEV_IP_CHANGE trap: %v", err)
+			}
+		case AH_MSG_TRAP_CLT_CAPS:
+			var cltCaps AhTelegrafCltCapsTrap
+			expected := int(unsafe.Sizeof(cltCaps))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid CLIENT CAPS size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [256]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering CLIENT CAPS trap: %v", err)
 			}
 		}
 	}

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -31,11 +31,14 @@ const (
 	AH_TRAP_SIZE_300	  = 300
 	AH_TRAP_SIZE_256         = 256
 	AH_MSG_TRAP_DEV_IP_CHANGE = 17
+	AH_MSG_TRAP_CLT_CAPS = 119
 	AH_MGT0_ADDR6_NUM_MAX    = 2
 	AH_SNMP_TRUE             = 1
 	AH_SNMP_FALSE            = 2
 	AH_MSG_TRAP_SET          = 0
 	AH_MSG_TRAP_CLEAR        = 1
+	AH_TRAP_CLT_CAPS_MAX_STR_LEN  = 12
+	AH_TRAP_CLT_CAPS_MIN_STR_LEN  = 8
 )
 
 const (
@@ -130,6 +133,26 @@ type AhTgrafDevIpChangeTrap struct {
 	Ipv6AddrNum        uint8
 	_                  [3]byte
 	Ipv6Data           [AH_MGT0_ADDR6_NUM_MAX]AhTgrafDevIpChangeIpv6Data
+}
+
+type AhTelegrafCltCapsTrap struct {
+	TrapType    uint8
+	CltMac      [MACADDR_LEN]byte
+	BssidMac    [MACADDR_LEN]byte
+	Channel     uint8
+	Type        [AH_TRAP_CLT_CAPS_MAX_STR_LEN]byte
+	Bw          [AH_TRAP_CLT_CAPS_MAX_STR_LEN]byte
+	Nss         uint8
+	Mode        [AH_TRAP_CLT_CAPS_MAX_STR_LEN]byte
+	MinTxPower  int8
+	MaxTxPower  int8
+	MuMimo      [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
+	Wmm         [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
+	Cipher      [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
+	Akm         [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
+	Mfp         [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
+	Mobile      [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
+	Uapsd       [AH_TRAP_CLT_CAPS_MIN_STR_LEN]byte
 }
 
 type AhFailureTrap struct {


### PR DESCRIPTION
'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'clientCapabilitiesTrap': {'akm': 'NONE', 'bandWidth': '20MHz', 'bssidMac': '24:1F:BD:8F:E7:54', 'channel': 6, 'cipher': 'OPEN', 'clientMac': '7C:70:DB:07:6A:98', 'frameType': 'ASSOC_REQ', 'mfp': 'UNKNOWN', 'mobility': 'UNKNOWN', 'muMimo': 'UNKNOWN', 'nss': 1, 'phyMode': '802.11bg', 'trapType': 119, 'uapsd': 'DISABLE', 'wmm': 'ENABLE'}, 'ssidBindUnbindTrap': {'trapMessage': {'isClear': False}}}], 'name': 'TrapEvent', 'ts': 1771493856671}]}
10.42.0.2 - - [23/Feb/2026 14:05:49] "POST /telegraf/rest/v1 HTTP/1.1" 20
