### PR TITLE
HOS-24825 : Implement trap AH_MSG_TRAP_VERIFY_OOB_SN over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -429,6 +429,14 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"serialNumber_oobSerialNumberTrap":   ahutil.CleanCString(oobSn.SerialNumber[:]),
 			"isClear_trapMessage_oobSerialNumberTrap": GetTrapClearStatus(uint32(oobSn.TrapType), trapBuf[:]),
 		}, nil)
+	case AH_MSG_TRAP_PORTAL_CHANGE:
+		var portalChange  AhPortalChangeTrap
+		copy((*[unsafe.Sizeof(portalChange)]byte)(unsafe.Pointer(&portalChange))[:], trapBuf[:unsafe.Sizeof(portalChange)])
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapId_portalChangeTrap":      portalChange.TrapType,
+			"macAddr_portalChangeTrap":    ahutil.FormatMac(portalChange.Macaddr),
+			"isClear_trapMessage_portalChangeTrap": GetTrapClearStatus(uint32(portalChange.TrapType), trapBuf[:]),
+		}, nil)
 	}
 
 	return nil
@@ -651,6 +659,18 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering OutOfBox SerialNumber trap: %v", err)
+			}
+		case AH_MSG_TRAP_PORTAL_CHANGE:
+			var portalChange AhPortalChangeTrap
+			expected := int(unsafe.Sizeof(portalChange))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid Portal Change size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [AH_TRAP_SIZE_256]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering Portal Change trap: %v", err)
 			}
 		}
 	}

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -421,6 +421,14 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"ipv6Data_devIpChangeTrap":          formatDevIpChangeIpv6Data(devIpChange.Ipv6Data[:], int(devIpChange.Ipv6AddrNum)),
 			"isClear_trapMessage_devIpChangeTrap": GetTrapClearStatus(uint32(devIpChange.TrapType), trapBuf[:]),
 		}, nil)
+	case AH_MSG_TRAP_VERIFY_OOB_SN:
+		var oobSn  AhVerifyOobSnTrap
+		copy((*[unsafe.Sizeof(oobSn)]byte)(unsafe.Pointer(&oobSn))[:], trapBuf[:unsafe.Sizeof(oobSn)])
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapId_oobSerialNumberTrap":       oobSn.TrapType,
+			"serialNumber_oobSerialNumberTrap":   ahutil.CleanCString(oobSn.SerialNumber[:]),
+			"isClear_trapMessage_oobSerialNumberTrap": GetTrapClearStatus(uint32(oobSn.TrapType), trapBuf[:]),
+		}, nil)
 	}
 
 	return nil
@@ -631,6 +639,18 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering DEV_IP_CHANGE trap: %v", err)
+			}
+		case AH_MSG_TRAP_VERIFY_OOB_SN:
+			var oobSn  AhVerifyOobSnTrap
+			expected := int(unsafe.Sizeof(oobSn))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid OutOfBox SerialNumbe size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [AH_TRAP_SIZE_256]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering OutOfBox SerialNumber trap: %v", err)
 			}
 		}
 	}

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -37,6 +37,7 @@ const (
 	AH_MSG_TRAP_SET          = 0
 	AH_MSG_TRAP_CLEAR        = 1
 	AH_MSG_TRAP_VERIFY_OOB_SN  = 117
+	AH_MSG_TRAP_PORTAL_CHANGE  = 120
 )
 
 const (
@@ -138,6 +139,10 @@ type AhVerifyOobSnTrap struct {
 	SerialNumber [AH_MAX_NAME_LEN]byte;
 }
 
+type AhPortalChangeTrap struct {
+	TrapType	uint8;
+	Macaddr [MACADDR_LEN]byte;
+}
 type AhFailureTrap struct {
 	Name  [AH_MAX_TRAP_OBJ_NAME+1]byte
 	Cause int32

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -36,6 +36,7 @@ const (
 	AH_SNMP_FALSE            = 2
 	AH_MSG_TRAP_SET          = 0
 	AH_MSG_TRAP_CLEAR        = 1
+	AH_MSG_TRAP_VERIFY_OOB_SN  = 117
 )
 
 const (
@@ -130,6 +131,11 @@ type AhTgrafDevIpChangeTrap struct {
 	Ipv6AddrNum        uint8
 	_                  [3]byte
 	Ipv6Data           [AH_MGT0_ADDR6_NUM_MAX]AhTgrafDevIpChangeIpv6Data
+}
+
+type AhVerifyOobSnTrap struct {
+	TrapType	uint8;
+	SerialNumber [AH_MAX_NAME_LEN]byte;
 }
 
 type AhFailureTrap struct {


### PR DESCRIPTION
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'oobSerialNumberTrap': {'serialNumber': 'HB022236Y-10030', 'trapType': 117}}], 'name': 'TrapEvent', 'ts': 1771403143426}]}
10.42.0.2 - - [22/Feb/2026 12:51:22] "POST /telegraf/rest/v1 HTTP/1.1" 200 -

{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'portalChangeTrap': {'macAddr': '24:1F:BD:8F:E7:40', 'trapType': 120}}], 'name': 'TrapEvent', 'ts': 1771421566559}]}
10.42.0.2 - - [22/Feb/2026 18:00:18] "POST /telegraf/rest/v1 HTTP/1.1" 200 -