### PR TITLE
HOS-24822 : Implement AH_MSG_TRAP_RADIUSD_LDAP_ALARM trap over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -460,6 +460,16 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 			"uapsd_clientCapabilitiesTrap":       ahutil.CleanCString(cltCaps.Uapsd[:]),
 			"isClear_trapMessage_clientCapabilitiesTrap": GetTrapClearStatus(uint32(cltCaps.TrapType), trapBuf[:]),
 		}, nil)
+	case AH_MSG_TRAP_RADIUSD_LDAP_ALARM:
+		var ldapTrap AhTgrafLdapAlarmTrap
+		copy((*[unsafe.Sizeof(ldapTrap)]byte)(unsafe.Pointer(&ldapTrap))[:], trapBuf[:unsafe.Sizeof(ldapTrap)])
+		acc.AddFields("TrapEvent", map[string]interface{}{
+			"trapType_ldapAlarmTrap":            ldapTrap.TrapType,
+			"alarmType_ldapAlarmTrap":           ldapTrap.AlarmType,
+			"clear_ldapAlarmTrap":               ldapTrap.Clear,
+			"desc_ldapAlarmTrap":                ahutil.CleanCString(ldapTrap.Desc[:]),
+			"isClear_trapMessage_ldapAlarmTrap": GetTrapClearStatus(uint32(ldapTrap.TrapType), trapBuf[:]),
+		}, nil)
 	}
 
 	return nil
@@ -706,6 +716,18 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering CLIENT CAPS trap: %v", err)
+			}
+		case AH_MSG_TRAP_RADIUSD_LDAP_ALARM:
+			var ldapTrap AhTgrafLdapAlarmTrap
+			expected := int(unsafe.Sizeof(ldapTrap))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid LDAP ALARM size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [AH_TRAP_SIZE_256]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering LDAP ALARM trap: %v", err)
 			}
 		}
 	}

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -465,7 +465,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 		copy((*[unsafe.Sizeof(ldapTrap)]byte)(unsafe.Pointer(&ldapTrap))[:], trapBuf[:unsafe.Sizeof(ldapTrap)])
 		isClear := ldapTrap.Clear == 1
 		acc.AddFields("TrapEvent", map[string]interface{}{
-			"trapType_ldapAlarmTrap":            ldapTrap.TrapType,
+			"trapId_ldapAlarmTrap":              ldapTrap.TrapType,
 			"alarmType_ldapAlarmTrap":           ldapTrap.AlarmType,
 			"desc_ldapAlarmTrap":                ahutil.CleanCString(ldapTrap.Desc[:]),
 			"isClear_trapMessage_ldapAlarmTrap": isClear,

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -463,12 +463,12 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 	case AH_MSG_TRAP_RADIUSD_LDAP_ALARM:
 		var ldapTrap AhTgrafLdapAlarmTrap
 		copy((*[unsafe.Sizeof(ldapTrap)]byte)(unsafe.Pointer(&ldapTrap))[:], trapBuf[:unsafe.Sizeof(ldapTrap)])
+		isClear := ldapTrap.Clear == 1
 		acc.AddFields("TrapEvent", map[string]interface{}{
 			"trapType_ldapAlarmTrap":            ldapTrap.TrapType,
 			"alarmType_ldapAlarmTrap":           ldapTrap.AlarmType,
-			"clear_ldapAlarmTrap":               ldapTrap.Clear,
 			"desc_ldapAlarmTrap":                ahutil.CleanCString(ldapTrap.Desc[:]),
-			"isClear_trapMessage_ldapAlarmTrap": GetTrapClearStatus(uint32(ldapTrap.TrapType), trapBuf[:]),
+			"isClear_trapMessage_ldapAlarmTrap": isClear,
 		}, nil)
 	}
 

--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -466,7 +466,7 @@ func (t *TrapPlugin) Gather_Ah_send_trap(trapType uint32, trapBuf [256]byte, acc
 		isClear := ldapTrap.Clear == 1
 		acc.AddFields("TrapEvent", map[string]interface{}{
 			"trapId_ldapAlarmTrap":              ldapTrap.TrapType,
-			"alarmType_ldapAlarmTrap":           ldapTrap.AlarmType,
+			"alarmType_ldapAlarmTrap":           alarmTypeToString(ldapTrap.AlarmType),
 			"desc_ldapAlarmTrap":                ahutil.CleanCString(ldapTrap.Desc[:]),
 			"isClear_trapMessage_ldapAlarmTrap": isClear,
 		}, nil)

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -121,6 +121,17 @@ func clientAuthMethodToString(method int32) string {
 	}
 }
 
+func alarmTypeToString(alarmType int32) string {
+    switch alarmType {
+    case 0:
+        return "NET_JOIN"
+    case 1:
+        return "BIND_DN"
+    default:
+        return "UNKNOWN"
+    }
+}
+
 func clientEncryptMethodToString(method int32) string {
 	switch method {
 	case 0:

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -20,6 +20,7 @@ const (
 	AH_TRAP_MSG_TYPE         = 1
 	AH_FA_MVLAN_TRAP_TYPE    = 124
 	TRAP_DCRPT_LEN           = 96
+	AH_MSG_TRAP_RADIUSD_LDAP_ALARM = 9
 	AH_MSG_TRAP_DFS_BANG     = 12
 	AH_MSG_TRAP_STA_LEAVE_STATS = 6
 	MACADDR_LEN              = 6
@@ -226,6 +227,13 @@ type AhTgrafDevIpChangeTrap struct {
 	Ipv6AddrNum        uint8
 	_                  [3]byte
 	Ipv6Data           [AH_MGT0_ADDR6_NUM_MAX]AhTgrafDevIpChangeIpv6Data
+}
+
+type AhTgrafLdapAlarmTrap struct {
+	TrapType  uint8
+	AlarmType uint8
+	Clear     uint8
+	Desc      [TRAP_DCRPT_LEN]byte
 }
 
 type AhVerifyOobSnTrap struct {


### PR DESCRIPTION
This trap is triggered for miscellaneous system alarms or abnormal conditions on the AP that are not covered by specific trap types.

trap output 
{'trapEvent': [{'device': {'serialnumber': 'HA012235Y-10251'}, 'items':[{'ldapAlarmTrap': {'alarmType': 1, 'desc': 'Test RADIUS LDAP alarm trap', 'trapMessage': {'isClear': False}, 'trapId': 107}}], 'name': 'TrapEvent', 'ts': 1772116364808}]}

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
