### PR TITLE
HOS-24333 - Converted string arr to string for ipv6

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap_5020.go
+++ b/plugins/inputs/ah_trap/ah_trap_5020.go
@@ -5,6 +5,7 @@ package ah_trap
 import (
 	"unsafe"
 	"fmt"
+	"strings"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/common/ahutil"
 )
@@ -129,7 +130,7 @@ func (t *TrapPlugin) Ah_send_sta_leave_trap(trapType uint32, trapBuf [600]byte, 
 		"txairtime_staLeaveStatsTrap":		staLeave.TxAirTime,
 		"ts_staLeaveStatsTrap":				staLeave.Ts,
 		"staAddr6Num_staLeaveStatsTrap":	staLeave.StaAddr6Num,
-		"staAddr6_staLeaveStatsTrap":		IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)),
+		"staAddr6_staLeaveStatsTrap":		strings.Join(IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)), ","),
 		"isClear_trapMessage_staLeaveStatsTrap": GetTrapClearStatus(trapType, trapBuf[:]),
 	}, nil)
 	return nil

--- a/plugins/inputs/ah_trap/ah_trap_all.go
+++ b/plugins/inputs/ah_trap/ah_trap_all.go
@@ -5,6 +5,7 @@ package ah_trap
 import (
 	"log"
 	"unsafe"
+	"strings"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/common/ahutil"
 )
@@ -117,7 +118,7 @@ func (t *TrapPlugin) Ah_send_sta_leave_trap(trapType uint32, trapBuf [600]byte, 
 		"txairtime_staLeaveStatsTrap":		staLeave.TxAirTime,
 		"ts_staLeaveStatsTrap":				staLeave.Ts,
 		"staAddr6Num_staLeaveStatsTrap":	staLeave.StaAddr6Num,
-		"staAddr6_staLeaveStatsTrap":		IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)),
+		"staAddr6_staLeaveStatsTrap":		strings.Join(IntToIPv6_1(staLeave.StaAddr6[:], int(staLeave.StaAddr6Num)), ","),
 		"eventreasoncode_staLeaveStatsTrap":	staLeave.EventReasonCode,
 		"eventtype_staLeaveStatsTrap":		staLeave.EventType,
 		"isClear_trapMessage_staLeaveStatsTrap": GetTrapClearStatus(trapType, trapBuf[:]),


### PR DESCRIPTION
 - The telegraf serializer cannot interpret array of strings, hence converted the array to string separated by comma