### PR TITLE
HOS-24873: Changing ai-rrm id to 64bit

### DIFF
--- a/plugins/common/ahutil/ahutil.go
+++ b/plugins/common/ahutil/ahutil.go
@@ -389,14 +389,14 @@ func GetAPName() string {
     return "NA"
 }
 
-func GetRrmId() int {
-	var ret int
+func GetRrmId() int64 {
+	var ret int64
 	ret = 0
 	content, err := os.ReadFile("/tmp/rrmid")
 	if err != nil {
 		return 0
 	}
-	ret, err = strconv.Atoi(string(content))
+	ret, err = strconv.ParseInt(string(content), 10, 64)
 	if err != nil {
 		return 0
 	}

--- a/plugins/inputs/ah_airrm/ah_airrm_defines.go
+++ b/plugins/inputs/ah_airrm/ah_airrm_defines.go
@@ -49,8 +49,7 @@ type ah_ieee80211_airrm_nbr_tbl_t struct {
 
 // AIRRM neighbor information structure
 type ah_ieee80211_airrm_nbr_t struct {
-	rrmId					uint32			// unique identifier for RRM
-	_pad0					[4]byte			// pad to align timestamp (was implicit)
+	rrmId					uint64			// unique identifier for RRM
 	timestamp				uint64			// Date and timestamp
 	extremeAP				uint8			// Is AP managed by Extreme?
 	rssi					int8			// RSS value in dBm

--- a/plugins/inputs/ah_wireless/ah_wireless.go
+++ b/plugins/inputs/ah_wireless/ah_wireless.go
@@ -24,7 +24,7 @@ import (
 var (
 	offsetsMutex = new(sync.Mutex)
 	newLineByte  = []byte("\n")
-	rrmid int = 0
+	rrmid int64 = 0
 )
 
 

--- a/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
+++ b/plugins/inputs/ah_wireless_v2/ah_wireless_v2.go
@@ -24,7 +24,7 @@ import (
 var (
 	offsetsMutex = new(sync.Mutex)
 	newLineByte  = []byte("\n")
-	rrmid int = 0
+	rrmid int64 = 0
 )
 
 


### PR DESCRIPTION
Since ai-rrm id uses 64 bit integer in
driver. telegraf also needs to use 64bit.
This change fixes below two issues:
[HOS-24873]AIRRM: System Wireless AI RRM ID
Should Be Reflected In Reported Stats
Like RfStats
[HOS-24867][AI-RRM] Ai-rrm ID is displayed
wrongly on telegraf server o/p as compared
to AP ai-rrm neigh table info

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
