### PR TITLE
HOS-24886:Add AH_MSG_TRAP_FA_ASSGN_MAP_CHANGE trap over tgraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -605,9 +605,7 @@ func (t *TrapPlugin) Ah_send_capture_warn_trap(trapType uint32, trapBuf [600]byt
 		"trapId_captureTrap":      captureTrap.TrapId,
 		"description_captureTrap": ahutil.CleanCString(captureTrap.Desc[:]),
 		"totalSize_captureTrap":   captureTrap.TotalSize,
-		"trapMessage_captureTrap": map[string]interface{}{
-			"isClear_captureTrap": GetTrapClearStatus(uint32(captureTrap.TrapId), trapBuf[:]),
-		},
+		"isClear_trapMessage_captureTrap": GetTrapClearStatus(uint32(captureTrap.TrapId), trapBuf[:]),
 	}
 	if captureTrap.FileCount > 0 {
 		for i := 0; i < int(captureTrap.FileCount) && i < MAX_CAPTURE_FILES; i++ {
@@ -615,6 +613,28 @@ func (t *TrapPlugin) Ah_send_capture_warn_trap(trapType uint32, trapBuf [600]byt
 			fileSize := captureTrap.Files[i].FileSize
 			fields[fmt.Sprintf("name_@%d_capturedFiles_captureTrap", i)] = fileName
 			fields[fmt.Sprintf("size_@%d_capturedFiles_captureTrap", i)] = fileSize
+		}
+	}
+	acc.AddFields("TrapEvent", fields, nil)
+	return nil
+}
+
+func (t *TrapPlugin) Ah_send_fa_assign_map_trap(trapType uint32, trapBuf [800]byte, acc telegraf.Accumulator) error {
+	var faAssignTrap AhTgrafFaAssignMapChangeTrap
+	copy((*[unsafe.Sizeof(faAssignTrap)]byte)(unsafe.Pointer(&faAssignTrap))[:], trapBuf[:unsafe.Sizeof(faAssignTrap)])
+	fields := map[string]interface{}{
+		"trapId_faAssignTrap":      faAssignTrap.TrapId,
+		"ifIndex_faAssignTrap":     faAssignTrap.Ifindex,
+		"isClear_trapMessage_faAssignTrap": GetTrapClearStatus(uint32(faAssignTrap.TrapId), trapBuf[:]),
+	}
+	if faAssignTrap.Count > 0 && faAssignTrap.Count <= AH_TELEGRAF_FA_MAP_MAX_ENTRIES {
+		for i := 0; i < int(faAssignTrap.Count); i++ {
+			vlanId := faAssignTrap.Data[i].Vlan
+			isid := faAssignTrap.Data[i].Isid
+			state := MapStateToString(faAssignTrap.Data[i].State)
+			fields[fmt.Sprintf("vlanId_@%d_faMapData_faAssignTrap", i)] = vlanId
+			fields[fmt.Sprintf("isid_@%d_faMapData_faAssignTrap", i)] = isid
+			fields[fmt.Sprintf("state_@%d_faMapData_faAssignTrap", i)] = state
 		}
 	}
 	acc.AddFields("TrapEvent", fields, nil)
@@ -821,6 +841,18 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Gather_Ah_send_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering CAPWAP delay trap: %v", err)
+			}
+		case AH_MSG_TRAP_FA_ASSGN_MAP_CHANGE:
+			var faAssignTrap AhTgrafFaAssignMapChangeTrap
+			expected := int(unsafe.Sizeof(faAssignTrap))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid FA assign map change trap size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [800]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Ah_send_fa_assign_map_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error FA assign map change trap: %v", err)
 			}
 		}
 	}

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -48,6 +48,8 @@ const (
 	AH_CAPWAP_DELAY_TRAP     = 108
 	MAX_CAPTURE_FILE_NAME_LEN = 16
 	MAX_CAPTURE_FILES         = 16
+	AH_MSG_TRAP_FA_ASSGN_MAP_CHANGE = 126
+	AH_TELEGRAF_FA_MAP_MAX_ENTRIES = 94
 )
 
 const (
@@ -198,6 +200,18 @@ func clientMacProtoToString(proto int32) string {
 		return "UNKNOWN"
 	}
 }
+func MapStateToString(state uint8) string {
+	switch state {
+	case 1:
+		return "PENDING"
+	case 2:
+		return "ACCEPT"
+	case 3:
+		return "REJECT"
+	default:
+		return "UNKNOWN"
+	}
+}
 
 type AhFaMvlanChangeTrap struct {
 	TrapType      uint8
@@ -244,6 +258,21 @@ type AhTgrafCaptureWarnTrap struct {
     FileCount uint8
     _        [7]byte
     Files     [MAX_CAPTURE_FILES]AhCaptureFileInfo
+}
+
+type AhTgrafFaAssignMapData struct {
+       Isid  uint32
+       Vlan  uint16
+       State uint8
+       _     [1]byte
+}
+
+type AhTgrafFaAssignMapChangeTrap struct {
+       Ifindex int32
+       TrapId  uint8
+       Count   uint8
+       _       [2]byte
+       Data    [AH_TELEGRAF_FA_MAP_MAX_ENTRIES]AhTgrafFaAssignMapData
 }
 
 type AhTgrafCapwapDelayTrap struct {


### PR DESCRIPTION


{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'faAssignTrap': {'ifIndex': 10, 'faMapData': [{'isid': 10100, 'state': 'ACCEPT', 'vlanId': 10}, {'isid': 10200, 'state': 'ACCEPT', 'vlanId': 20}], 'trapId': 126, 'trapMessage': {'isClear': False}}}], 'name': 'TrapEvent', 'ts': 1772013363403}]}
10.42.0.2 - - [01/Mar/2026 14:44:29] "POST /telegraf/rest/v1 HTTP/1.1" 200 -


