### PR TITLE
HOS-24878: Add AH_MSG_TRAP_SELF_REG_INFO trap over tgraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime/debug"
 	"sync"
+	"time"
 	"unsafe"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -640,6 +641,24 @@ func (t *TrapPlugin) Ah_send_fa_assign_map_trap(trapType uint32, trapBuf [800]by
 	acc.AddFields("TrapEvent", fields, nil)
 	return nil
 }
+
+func (t *TrapPlugin) Ah_send_cwp_self_reg_info_send_trap(trapType uint32, trapBuf [800]byte, acc telegraf.Accumulator) error {
+    var CwpSelfRegInfoTrap AhTgrafCwpSelfRegInfoTrap
+    copy((*[unsafe.Sizeof(CwpSelfRegInfoTrap)]byte)(unsafe.Pointer(&CwpSelfRegInfoTrap))[:], trapBuf[:unsafe.Sizeof(CwpSelfRegInfoTrap)])
+
+    acc.AddFields("TrapEvent", map[string]interface{}{
+		"trapId_captivePortalSelfRegInfoTrap": CwpSelfRegInfoTrap.TrapType,
+		"stationMac_captivePortalSelfRegInfoTrap": ahutil.FormatMac(CwpSelfRegInfoTrap.StaMAC),
+		"expireTime_captivePortalSelfRegInfoTrap": time.Unix(int64(CwpSelfRegInfoTrap.ExpireTime), 0).UTC().Format(time.RFC3339),
+		"userName_captivePortalSelfRegInfoTrap": ahutil.CleanCString(CwpSelfRegInfoTrap.UserName[:]),
+		"email_captivePortalSelfRegInfoTrap": ahutil.CleanCString(CwpSelfRegInfoTrap.Email[:]),
+		"companyName_captivePortalSelfRegInfoTrap": ahutil.CleanCString(CwpSelfRegInfoTrap.CompanyName[:]),
+		"ssid_captivePortalSelfRegInfoTrap": ahutil.CleanCString(CwpSelfRegInfoTrap.CwpSsid[:]),
+		"isClear_trapMessage_captivePortalSelfRegInfoTrap": GetTrapClearStatus(trapType, trapBuf[:]),
+    }, nil)
+    return nil
+}
+
 /*
  trapListener listens for incoming trap messages on a UDP connection,
  extracts the trap type and payload, and processes supported trap types.
@@ -854,6 +873,19 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			if err := t.Ah_send_fa_assign_map_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error FA assign map change trap: %v", err)
 			}
+		case AH_MSG_TRAP_SELF_REG_INFO:
+			var CwpSelfRegInfoTrap AhTgrafCwpSelfRegInfoTrap
+			expected := int(unsafe.Sizeof(CwpSelfRegInfoTrap))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid Captive Portal self reg info trap size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [800]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Ah_send_cwp_self_reg_info_send_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering Captive Portal self reg info trap: %v", err)
+			}
+
 		}
 	}
 }

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -50,6 +50,9 @@ const (
 	MAX_CAPTURE_FILES         = 16
 	AH_MSG_TRAP_FA_ASSGN_MAP_CHANGE = 126
 	AH_TELEGRAF_FA_MAP_MAX_ENTRIES = 94
+	AH_TELEGRAF_SELF_REG_MAX_LEN  = 129
+	AH_TELEGRAF_SELF_REG_USER_LEN = 257
+	AH_MSG_TRAP_SELF_REG_INFO     = 11
 )
 
 const (
@@ -365,6 +368,16 @@ type AhTgrafSsidBindUnbindTrap struct {
 	BssidMAC    [MACADDR_LEN]byte
 	SSID        [AH_MAX_TRAP_SSID_NAME + 1]byte
 	State       uint8
+}
+
+type AhTgrafCwpSelfRegInfoTrap struct {
+        TrapType    uint8
+        StaMAC      [MACADDR_LEN]byte
+        ExpireTime  uint32
+        UserName    [AH_TELEGRAF_SELF_REG_USER_LEN]byte
+        Email       [AH_TELEGRAF_SELF_REG_MAX_LEN]byte
+        CompanyName [AH_TELEGRAF_SELF_REG_MAX_LEN]byte
+        CwpSsid     [AH_TELEGRAF_SELF_REG_MAX_LEN]byte
 }
 
 type AhTgrafBSSIDSpoofingTrap struct {


### PR DESCRIPTION
10.42.0.2 - - [02/Mar/2026 11:39:38] "POST /telegraf/rest/v1 HTTP/1.1" 200 -
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'CwpSelfRegInfoTrap': {'companyName': '', 'email': '[testX@gmail.com](mailto:testX@gmail.com)', 'expireTime': '2026-03-04T05:11:46Z', 'ssid': 'cwp_ssid', 'stationMac': 'F8:B5:4D:6E:BE:50', 'trapId': 109, 'trapMessage': {'isClear': False}, 'userName': 'Test User'}}], 'name': 'TrapEvent', 'ts': 1772090491217}]}