### PR TITLE
HOS-24898: Implement AH_MSG_TRAP_REPORT_CWP_INFO over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -659,6 +659,35 @@ func (t *TrapPlugin) Ah_send_cwp_self_reg_info_send_trap(trapType uint32, trapBu
     return nil
 }
 
+func (t *TrapPlugin) Ah_send_cwp_info_trap(trapType uint32, trapBuf [2046]byte, acc telegraf.Accumulator) error {
+    var CwpInfoTrap AhTgrafCwpInfoTrap
+    copy((*[unsafe.Sizeof(CwpInfoTrap)]byte)(unsafe.Pointer(&CwpInfoTrap))[:], trapBuf[:unsafe.Sizeof(CwpInfoTrap)])
+
+    fields := map[string]interface{}{
+        "trapId_captivePortalFieldInfoTrap": CwpInfoTrap.TrapType,
+        "stationMac_captivePortalFieldInfoTrap": ahutil.FormatMac(CwpInfoTrap.MacAddr),
+        "objectName_captivePortalFieldInfoTrap": ahutil.CleanCString(CwpInfoTrap.ObjName[:]),
+        "isClear_trapMessage_captivePortalFieldInfoTrap": GetTrapClearStatus(trapType, trapBuf[:]),
+    }
+
+    for i := uint8(0); i < CwpInfoTrap.FieldCount && i < AH_TELEGRAF_CWP_MAX_FIELDS; i++ {
+        fieldName := ahutil.CleanCString(CwpInfoTrap.Fields[i].Name[:])
+        fieldValue := ahutil.CleanCString(CwpInfoTrap.Fields[i].Value[:])
+        fields[fmt.Sprintf("name_@%d_mandatoryFields_captivePortalFieldInfoTrap", i)] = fieldName
+        fields[fmt.Sprintf("value_@%d_mandatoryFields_captivePortalFieldInfoTrap", i)] = fieldValue
+    }
+
+    for i := uint8(0); i < CwpInfoTrap.OptFieldCount && i < AH_TELEGRAF_CWP_MAX_OPT_FIELDS; i++ {
+        fieldName := ahutil.CleanCString(CwpInfoTrap.OptFields[i].Name[:])
+        fieldValue := ahutil.CleanCString(CwpInfoTrap.OptFields[i].Value[:])
+        fields[fmt.Sprintf("name_@%d_optionalFields_captivePortalFieldInfoTrap", i)] = fieldName
+        fields[fmt.Sprintf("value_@%d_optionalFields_captivePortalFieldInfoTrap", i)] = fieldValue
+    }
+
+    acc.AddFields("TrapEvent", fields, nil)
+    return nil
+}
+
 /*
  trapListener listens for incoming trap messages on a UDP connection,
  extracts the trap type and payload, and processes supported trap types.
@@ -885,7 +914,18 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			if err := t.Ah_send_cwp_self_reg_info_send_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering Captive Portal self reg info trap: %v", err)
 			}
-
+		case AH_MSG_TRAP_REPORT_CWP_INFO:
+			var CwpInfoTrap AhTgrafCwpInfoTrap
+			expected := int(unsafe.Sizeof(CwpInfoTrap))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid CWP info trap size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [2046]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Ah_send_cwp_info_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering CWP info trap: %v", err)
+			}
 		}
 	}
 }

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -53,6 +53,12 @@ const (
 	AH_TELEGRAF_SELF_REG_MAX_LEN  = 129
 	AH_TELEGRAF_SELF_REG_USER_LEN = 257
 	AH_MSG_TRAP_SELF_REG_INFO     = 11
+	AH_MSG_TRAP_REPORT_CWP_INFO   = 15
+	AH_TELEGRAF_CWP_FIELD_NAME_LEN = 50
+	AH_TELEGRAF_CWP_FIELD_LEN      = 65
+	AH_TELEGRAF_CWP_MAX_FIELDS     = 8
+	AH_TELEGRAF_CWP_MAX_OPT_FIELDS = 8
+
 )
 
 const (
@@ -378,6 +384,21 @@ type AhTgrafCwpSelfRegInfoTrap struct {
         Email       [AH_TELEGRAF_SELF_REG_MAX_LEN]byte
         CompanyName [AH_TELEGRAF_SELF_REG_MAX_LEN]byte
         CwpSsid     [AH_TELEGRAF_SELF_REG_MAX_LEN]byte
+}
+
+type AhTgrafCwpField struct {
+        Name  [AH_TELEGRAF_CWP_FIELD_NAME_LEN]byte
+        Value [AH_TELEGRAF_CWP_FIELD_LEN]byte
+}
+
+type AhTgrafCwpInfoTrap struct {
+        TrapType      uint8
+        MacAddr       [MACADDR_LEN]byte
+        ObjName       [6]byte
+        FieldCount    uint8
+        OptFieldCount uint8
+        Fields        [AH_TELEGRAF_CWP_MAX_FIELDS]AhTgrafCwpField
+        OptFields     [AH_TELEGRAF_CWP_MAX_OPT_FIELDS]AhTgrafCwpField
 }
 
 type AhTgrafBSSIDSpoofingTrap struct {


### PR DESCRIPTION
192.168.1.219 - - [05/Mar/2026 12:30:40] "POST /telegraf/rest/v1 HTTP/1.1" 200 -
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'captivePortalFieldInfoTrap': {' mandatoryFields': [{'name': 'first name', 'value': 'Test'}, {'name': 'last name', 'value': 'user'}, {'name': 'email', 'value': 'test@gmail.com'}, {'name': 'visiting', 'value': 'extreme'}], 'objName': 'AUTH', 'optionalFields': [{'name': 'phone', 'value': '1234567890'}, {'name': 'reason', 'value': ''}], 'stationMac': 'F8:B5:4D:6E:BE:50', 'trapId': 114, 'trapMessage': {'isClear': False}}}], 'name': 'TrapEvent', 'ts': 1772695024228}]}
192.168.1.219 - - [05/Mar/2026 12:47:06] "POST /telegraf/rest/v1 HTTP/1.1" 200 -

