### PR TITLE
HOS-24823: Implement trap AH_MSG_TRAP_GENERIC_ALARM over telegraf

### DIFF
--- a/plugins/inputs/ah_trap/ah_trap.go
+++ b/plugins/inputs/ah_trap/ah_trap.go
@@ -688,6 +688,38 @@ func (t *TrapPlugin) Ah_send_cwp_info_trap(trapType uint32, trapBuf [2046]byte, 
     return nil
 }
 
+func (t *TrapPlugin) Ah_send_generic_alarm_trap(trapType uint32, trapBuf [2048]byte, acc telegraf.Accumulator) error {
+	var genericAlarmTrap AhTelegrafGenericAlarmTrap
+	copy((*[unsafe.Sizeof(genericAlarmTrap)]byte)(unsafe.Pointer(&genericAlarmTrap))[:], trapBuf[:unsafe.Sizeof(genericAlarmTrap)])
+
+	fields := map[string]interface{}{
+		"trapId_genericAlarmTrap": genericAlarmTrap.TrapType,
+	}
+
+	itemCount := int(genericAlarmTrap.ItemNum)
+	if itemCount > AH_TELEGRAF_GENERIC_ALARM_MAX_ITEMS {
+		itemCount = AH_TELEGRAF_GENERIC_ALARM_MAX_ITEMS
+	}
+
+	for i := 0; i < itemCount; i++ {
+		item := genericAlarmTrap.Items[i]
+		fields[fmt.Sprintf("alarmId_@%d_alarms_genericAlarmTrap", i)] = item.AlarmId
+		fields[fmt.Sprintf("severityLevel_trapMessage_@%d_alarms_genericAlarmTrap", i)] = severityToString(int32(item.Severity))
+		fields[fmt.Sprintf("desc_trapMessage_@%d_alarms_genericAlarmTrap", i)] = ahutil.CleanCString(item.Desc[:])
+		fields[fmt.Sprintf("tag1_@%d_alarms_genericAlarmTrap", i)] = item.Tag1
+		fields[fmt.Sprintf("tag2_@%d_alarms_genericAlarmTrap", i)] = item.Tag2
+		fields[fmt.Sprintf("tag3_@%d_alarms_genericAlarmTrap", i)] = ahutil.CleanCString(item.Tag3[:])
+		if item.Clear == 1 {
+			fields[fmt.Sprintf("isClear_trapMessage_@%d_alarms_genericAlarmTrap", i)] = "true"
+		} else {
+			fields[fmt.Sprintf("isClear_trapMessage_@%d_alarms_genericAlarmTrap", i)] = "false"
+		}
+	}
+
+	acc.AddFields("TrapEvent", fields, nil)
+	return nil
+}
+
 /*
  trapListener listens for incoming trap messages on a UDP connection,
  extracts the trap type and payload, and processes supported trap types.
@@ -925,6 +957,18 @@ func (t *TrapPlugin) trapListener(conn net.PacketConn) {
 			copy(trapBuf[:expected], payload)
 			if err := t.Ah_send_cwp_info_trap(trapType, trapBuf, t.acc); err != nil {
 				log.Printf("[ah_trap] Error gathering CWP info trap: %v", err)
+			}
+		case AH_MSG_TRAP_GENERIC_ALARM:
+			var genericAlarmTrap AhTelegrafGenericAlarmTrap
+			expected := int(unsafe.Sizeof(genericAlarmTrap))
+			if len(payload) != expected {
+				log.Printf("[ah_trap] Invalid Generic Alarm trap size: got %d, expected %d", len(payload), expected)
+				continue
+			}
+			var trapBuf [2048]byte
+			copy(trapBuf[:expected], payload)
+			if err := t.Ah_send_generic_alarm_trap(trapType, trapBuf, t.acc); err != nil {
+				log.Printf("[ah_trap] Error gathering Generic Alarm trap: %v", err)
 			}
 		}
 	}

--- a/plugins/inputs/ah_trap/ah_trap_defines_common.go
+++ b/plugins/inputs/ah_trap/ah_trap_defines_common.go
@@ -58,7 +58,10 @@ const (
 	AH_TELEGRAF_CWP_FIELD_LEN      = 65
 	AH_TELEGRAF_CWP_MAX_FIELDS     = 8
 	AH_TELEGRAF_CWP_MAX_OPT_FIELDS = 8
-
+	AH_MSG_TRAP_GENERIC_ALARM     = 113
+	AH_TELEGRAF_GENERIC_ALARM_DESC_LEN   = 256
+	AH_TELEGRAF_GENERIC_ALARM_TAG3_LEN   = 64
+	AH_TELEGRAF_GENERIC_ALARM_MAX_ITEMS  = 6
 )
 
 const (
@@ -416,6 +419,23 @@ type AhTgrafCwpInfoTrap struct {
         OptFieldCount uint8
         Fields        [AH_TELEGRAF_CWP_MAX_FIELDS]AhTgrafCwpField
         OptFields     [AH_TELEGRAF_CWP_MAX_OPT_FIELDS]AhTgrafCwpField
+}
+
+type AhTelegrafGenericAlarmItem struct {
+       AlarmId  uint16
+       Severity uint8
+       Clear    uint8
+       Desc     [AH_TELEGRAF_GENERIC_ALARM_DESC_LEN]byte
+       Tag1     int32
+       Tag2     int32
+       Tag3     [AH_TELEGRAF_GENERIC_ALARM_TAG3_LEN]byte
+}
+
+type AhTelegrafGenericAlarmTrap struct {
+       TrapType uint8
+       _        [1]byte
+       ItemNum  uint16
+       Items    [AH_TELEGRAF_GENERIC_ALARM_MAX_ITEMS]AhTelegrafGenericAlarmItem
 }
 
 type AhTgrafBSSIDSpoofingTrap struct {


### PR DESCRIPTION
{'trapEvent': [{'device': {'serialnumber': 'HA022235Y-10020'}, 'items': [{'genericAlarmTrap': {'alarms': [{'alarmId': 1, 'tag1': -1, 'tag2': -1, 'tag3': '', 'trapMessage': {'desc': 'Currently, there is no radsec proxy in this DA domain', 'isClear': 'false', 'severityLevel': 'MINOR'}}], 'trapId': 113}}], 'name': 'TrapEvent', 'ts': 1772791884791}]}
192.168.1.219 - - [06/Mar/2026 15:41:27] "POST /telegraf/rest/v1 HTTP/1.1" 200 -
